### PR TITLE
Send detector-spectrum map messages

### DIFF
--- a/event_data/CMakeLists.txt
+++ b/event_data/CMakeLists.txt
@@ -2,15 +2,18 @@ project(isis_nexus_streamer)
 
 set( SRC_FILES
         src/EventData.cpp
-        src/RunData.cpp)
+        src/RunData.cpp
+        src/DetectorSpectrumMapData.cpp)
 
 set( INC_FILES
         include/EventData.h
-        include/RunData.h)
+        include/RunData.h
+        include/DetectorSpectrumMapData.h)
 
 set( TEST_FILES
         test/EventDataTest.cpp
-        test/RunDataTest.cpp)
+        test/RunDataTest.cpp
+        test/DetectorSpectrumMapDataTest.cpp)
 
 #####################
 ## Libraries       ##
@@ -21,6 +24,7 @@ include_directories(
 
 add_library(eventdata_lib ${PROJECT_SOURCE_DIR}/src/EventData.cpp)
 add_library(rundata_lib ${PROJECT_SOURCE_DIR}/src/RunData.cpp)
+add_library(detSpecMapData_lib ${PROJECT_SOURCE_DIR}/src/DetectorSpectrumMapData.cpp)
 
 #####################
 ## Unit Tests      ##
@@ -30,7 +34,8 @@ set(eventData_tests_LINK_LIBRARIES
         gtest
         gmock
         eventdata_lib
-        rundata_lib)
+        rundata_lib
+        detSpecMapData_lib)
 if(UNIX)
     list(APPEND tests_LINK_LIBRARIES pthread)
 endif()

--- a/event_data/include/DetectorSpectrumMapData.h
+++ b/event_data/include/DetectorSpectrumMapData.h
@@ -1,0 +1,19 @@
+#ifndef ISIS_NEXUS_STREAMER_FOR_MANTID_DETECTORSPECTRUMMAPDATA_H
+#define ISIS_NEXUS_STREAMER_FOR_MANTID_DETECTORSPECTRUMMAPDATA_H
+
+#include "det_spec_mapping_schema_generated.h"
+
+class DetectorSpectrumMapData {
+public:
+  DetectorSpectrumMapData(const std::string &filename);
+
+  size_t getNumberOfEntries() { return m_numberOfEntries; }
+
+private:
+  void readFile(const std::string &filename);
+  size_t m_numberOfEntries = 0;
+  std::vector<int32_t> m_detectors;
+  std::vector<int32_t> m_spectra;
+};
+
+#endif // ISIS_NEXUS_STREAMER_FOR_MANTID_DETECTORSPECTRUMMAPDATA_H

--- a/event_data/include/DetectorSpectrumMapData.h
+++ b/event_data/include/DetectorSpectrumMapData.h
@@ -8,7 +8,7 @@ public:
   DetectorSpectrumMapData() {}
   DetectorSpectrumMapData(const std::string &filename);
 
-  flatbuffers::unique_ptr_t getEventBufferPointer(std::string &buffer);
+  flatbuffers::unique_ptr_t getBufferPointer(std::string &buffer);
   void decodeMessage(const uint8_t *buf);
 
   size_t getNumberOfEntries() { return m_numberOfEntries; }

--- a/event_data/include/DetectorSpectrumMapData.h
+++ b/event_data/include/DetectorSpectrumMapData.h
@@ -5,15 +5,25 @@
 
 class DetectorSpectrumMapData {
 public:
+  DetectorSpectrumMapData() {}
   DetectorSpectrumMapData(const std::string &filename);
+
+  flatbuffers::unique_ptr_t getEventBufferPointer(std::string &buffer);
+  void decodeMessage(const uint8_t *buf);
 
   size_t getNumberOfEntries() { return m_numberOfEntries; }
   std::vector<int32_t> getDetectors() { return m_detectors; }
   std::vector<int32_t> getSpectra() { return m_spectra; }
+  size_t getBufferSize() { return m_bufferSize; }
+
+  void setNumberOfEntries(size_t numberOfEntries) {
+    m_numberOfEntries = numberOfEntries;
+  }
 
 private:
   void readFile(const std::string &filename);
   size_t m_numberOfEntries = 0;
+  size_t m_bufferSize = 0;
   std::vector<int32_t> m_detectors;
   std::vector<int32_t> m_spectra;
 };

--- a/event_data/include/DetectorSpectrumMapData.h
+++ b/event_data/include/DetectorSpectrumMapData.h
@@ -8,6 +8,8 @@ public:
   DetectorSpectrumMapData(const std::string &filename);
 
   size_t getNumberOfEntries() { return m_numberOfEntries; }
+  std::vector<int32_t> getDetectors() { return m_detectors; }
+  std::vector<int32_t> getSpectra() { return m_spectra; }
 
 private:
   void readFile(const std::string &filename);

--- a/event_data/include/EventData.h
+++ b/event_data/include/EventData.h
@@ -10,37 +10,39 @@ class EventData {
 
 public:
   // Construct a new empty EventData object
-  EventData(){};
+  EventData() {}
 
   // Decode message into existing EventData instance
   bool decodeMessage(const uint8_t *buf);
 
   // Setters
-  void setDetId(std::vector<int32_t> detIds) { m_detId = detIds; };
-  void setTof(std::vector<float> tofs) { m_tof = tofs; };
-  void setFrameNumber(int32_t frameNumber) { m_frameNumber = frameNumber; };
-  void setTotalCounts(uint64_t totalCounts) { m_totalCounts = totalCounts; };
-  void setEndOfFrame(bool lastInFrame) { m_endOfFrame = lastInFrame; };
-  void setEndOfRun(bool lastInRun) { m_endOfRun = lastInRun; };
-  void setProtonCharge(float protonCharge) { m_protonCharge = protonCharge; };
-  void setPeriod(int32_t period) { m_period = period; };
-  void setFrameTime(float frameTime) { m_frameTime = frameTime; };
+  void setDetId(std::vector<int32_t> detIds) { m_detId = detIds; }
+  void setTof(std::vector<float> tofs) { m_tof = tofs; }
+  void setFrameNumber(int32_t frameNumber) { m_frameNumber = frameNumber; }
+  void setTotalCounts(uint64_t totalCounts) { m_totalCounts = totalCounts; }
+  void setEndOfFrame(bool lastInFrame) { m_endOfFrame = lastInFrame; }
+  void setEndOfRun(bool lastInRun) { m_endOfRun = lastInRun; }
+  void setProtonCharge(float protonCharge) { m_protonCharge = protonCharge; }
+  void setPeriod(int32_t period) { m_period = period; }
+  void setFrameTime(float frameTime) { m_frameTime = frameTime; }
 
   // Getters
-  std::vector<int32_t> getDetId() { return m_detId; };
-  std::vector<float> getTof() { return m_tof; };
-  uint32_t getFrameNumber() { return m_frameNumber; };
-  uint32_t getNumberOfEvents() { return m_tof.size(); };
-  uint64_t getTotalCounts() { return m_totalCounts; };
-  bool getEndOfFrame() { return m_endOfFrame; };
-  bool getEndOfRun() { return m_endOfRun; };
-  float getProtonCharge() { return m_protonCharge; };
-  int32_t getPeriod() { return m_period; };
-  float getFrameTime() { return m_frameTime; };
+  std::vector<int32_t> getDetId() { return m_detId; }
+  std::vector<float> getTof() { return m_tof; }
+  uint32_t getFrameNumber() { return m_frameNumber; }
+  uint32_t getNumberOfEvents() { return m_tof.size(); }
+  uint64_t getTotalCounts() { return m_totalCounts; }
+  bool getEndOfFrame() { return m_endOfFrame; }
+  bool getEndOfRun() { return m_endOfRun; }
+  float getProtonCharge() { return m_protonCharge; }
+  int32_t getPeriod() { return m_period; }
+  float getFrameTime() { return m_frameTime; }
 
   flatbuffers::unique_ptr_t getBufferPointer(std::string &buffer);
 
-  size_t getBufferSize() { return m_bufferSize; };
+      size_t getBufferSize() {
+    return m_bufferSize;
+  }
 
 private:
   // Default values here should match default values in the schema

--- a/event_data/src/DetectorSpectrumMapData.cpp
+++ b/event_data/src/DetectorSpectrumMapData.cpp
@@ -17,8 +17,7 @@ void DetectorSpectrumMapData::readFile(const std::string &filename) {
   m_spectra.resize(m_numberOfEntries);
   std::getline(infile, line); // discard third line
   size_t entryNumber = 0;
-  while (std::getline(infile, line))
-  {
+  while (std::getline(infile, line)) {
     std::istringstream iss(line);
     if (!(iss >> m_detectors[entryNumber] >> m_spectra[entryNumber])) {
       break;
@@ -26,4 +25,34 @@ void DetectorSpectrumMapData::readFile(const std::string &filename) {
 
     entryNumber++;
   }
+}
+
+void DetectorSpectrumMapData::decodeMessage(const uint8_t *buf) {
+  auto messageData = ISISDAE::GetSpectraDetectorMapping(buf);
+
+  auto detFBVector = messageData->det();
+  auto specFBVector = messageData->spec();
+  setNumberOfEntries(detFBVector->size());
+  m_detectors.resize(m_numberOfEntries);
+  m_spectra.resize(m_numberOfEntries);
+  std::copy(detFBVector->begin(), detFBVector->end(), m_detectors.begin());
+  std::copy(specFBVector->begin(), specFBVector->end(), m_spectra.begin());
+}
+
+flatbuffers::unique_ptr_t
+DetectorSpectrumMapData::getEventBufferPointer(std::string &buffer) {
+  flatbuffers::FlatBufferBuilder builder;
+
+  auto messageFlatbuf = ISISDAE::CreateSpectraDetectorMapping(
+      builder, builder.CreateVector(m_spectra),
+      builder.CreateVector(m_detectors));
+  builder.Finish(messageFlatbuf);
+
+  auto bufferpointer =
+      reinterpret_cast<const char *>(builder.GetBufferPointer());
+  buffer.assign(bufferpointer, bufferpointer + builder.GetSize());
+
+  m_bufferSize = builder.GetSize();
+
+  return builder.ReleaseBufferPointer();
 }

--- a/event_data/src/DetectorSpectrumMapData.cpp
+++ b/event_data/src/DetectorSpectrumMapData.cpp
@@ -40,7 +40,7 @@ void DetectorSpectrumMapData::decodeMessage(const uint8_t *buf) {
 }
 
 flatbuffers::unique_ptr_t
-DetectorSpectrumMapData::getEventBufferPointer(std::string &buffer) {
+DetectorSpectrumMapData::getBufferPointer(std::string &buffer) {
   flatbuffers::FlatBufferBuilder builder;
 
   auto messageFlatbuf = ISISDAE::CreateSpectraDetectorMapping(

--- a/event_data/src/DetectorSpectrumMapData.cpp
+++ b/event_data/src/DetectorSpectrumMapData.cpp
@@ -1,0 +1,29 @@
+#include "DetectorSpectrumMapData.h"
+#include <fstream>
+#include <sstream>
+
+DetectorSpectrumMapData::DetectorSpectrumMapData(const std::string &filename) {
+  readFile(filename);
+}
+
+void DetectorSpectrumMapData::readFile(const std::string &filename) {
+  std::ifstream infile(filename);
+  std::string line;
+  std::getline(infile, line); // discard first line
+  std::getline(infile, line); // line with the number of entries
+  std::istringstream iss(line);
+  iss >> m_numberOfEntries;
+  m_detectors.resize(m_numberOfEntries);
+  m_spectra.resize(m_numberOfEntries);
+  std::getline(infile, line); // discard third line
+  size_t entryNumber = 0;
+  while (std::getline(infile, line))
+  {
+    std::istringstream iss(line);
+    if (!(iss >> m_detectors[entryNumber] >> m_spectra[entryNumber])) {
+      break;
+    } // error
+
+    entryNumber++;
+  }
+}

--- a/event_data/test/DetectorSpectrumMapDataTest.cpp
+++ b/event_data/test/DetectorSpectrumMapDataTest.cpp
@@ -9,8 +9,24 @@ TEST(DetectorSpectrumMapDataTest, read_detector_spectrum_map_file) {
   EXPECT_NO_THROW(DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat"));
 }
 
-TEST(DetectorSpectrumMapDataTest, read_detector_spectrum_map_data) {
+TEST(DetectorSpectrumMapDataTest, read_detector_spectrum_map_detectors) {
   extern std::string testDataPath;
   auto detSpecMap = DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat");
   EXPECT_EQ(245768, detSpecMap.getNumberOfEntries());
+
+  auto detectors = detSpecMap.getDetectors();
+  EXPECT_EQ(1, detectors[0]);
+  EXPECT_EQ(1100000, detectors[8]);
+  EXPECT_EQ(4523511, detectors[245767]);
+}
+
+TEST(DetectorSpectrumMapDataTest, read_detector_spectrum_map_spectra) {
+  extern std::string testDataPath;
+  auto detSpecMap = DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat");
+  EXPECT_EQ(245768, detSpecMap.getNumberOfEntries());
+
+  auto spectra = detSpecMap.getSpectra();
+  EXPECT_EQ(1, spectra[0]);
+  EXPECT_EQ(9, spectra[8]);
+  EXPECT_EQ(245768, spectra[245767]);
 }

--- a/event_data/test/DetectorSpectrumMapDataTest.cpp
+++ b/event_data/test/DetectorSpectrumMapDataTest.cpp
@@ -6,12 +6,14 @@ class DetectorSpectrumMapDataTest : public ::testing::Test {};
 
 TEST(DetectorSpectrumMapDataTest, read_detector_spectrum_map_file) {
   extern std::string testDataPath;
-  EXPECT_NO_THROW(DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat"));
+  EXPECT_NO_THROW(
+      DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat"));
 }
 
 TEST(DetectorSpectrumMapDataTest, read_detector_spectrum_map_detectors) {
   extern std::string testDataPath;
-  auto detSpecMap = DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat");
+  auto detSpecMap =
+      DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat");
   EXPECT_EQ(245768, detSpecMap.getNumberOfEntries());
 
   auto detectors = detSpecMap.getDetectors();
@@ -22,10 +24,35 @@ TEST(DetectorSpectrumMapDataTest, read_detector_spectrum_map_detectors) {
 
 TEST(DetectorSpectrumMapDataTest, read_detector_spectrum_map_spectra) {
   extern std::string testDataPath;
-  auto detSpecMap = DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat");
+  auto detSpecMap =
+      DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat");
   EXPECT_EQ(245768, detSpecMap.getNumberOfEntries());
 
   auto spectra = detSpecMap.getSpectra();
+  EXPECT_EQ(1, spectra[0]);
+  EXPECT_EQ(9, spectra[8]);
+  EXPECT_EQ(245768, spectra[245767]);
+}
+
+TEST(DetectorSpectrumMapDataTest, create_message_buffer) {
+  extern std::string testDataPath;
+  auto detSpecMap =
+      DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat");
+
+  std::string rawbuf;
+  EXPECT_NO_THROW(detSpecMap.getEventBufferPointer(rawbuf));
+
+  auto receivedMapData = DetectorSpectrumMapData();
+  EXPECT_NO_THROW(receivedMapData.decodeMessage(
+      reinterpret_cast<const uint8_t *>(rawbuf.c_str())));
+  EXPECT_EQ(245768, receivedMapData.getNumberOfEntries());
+
+  auto detectors = receivedMapData.getDetectors();
+  EXPECT_EQ(1, detectors[0]);
+  EXPECT_EQ(1100000, detectors[8]);
+  EXPECT_EQ(4523511, detectors[245767]);
+
+  auto spectra = receivedMapData.getSpectra();
   EXPECT_EQ(1, spectra[0]);
   EXPECT_EQ(9, spectra[8]);
   EXPECT_EQ(245768, spectra[245767]);

--- a/event_data/test/DetectorSpectrumMapDataTest.cpp
+++ b/event_data/test/DetectorSpectrumMapDataTest.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+
+#include "../include/DetectorSpectrumMapData.h"
+
+class DetectorSpectrumMapDataTest : public ::testing::Test {};
+
+TEST(DetectorSpectrumMapDataTest, read_detector_spectrum_map_file) {
+  extern std::string testDataPath;
+  EXPECT_NO_THROW(DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat"));
+}
+
+TEST(DetectorSpectrumMapDataTest, read_detector_spectrum_map_data) {
+  extern std::string testDataPath;
+  auto detSpecMap = DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat");
+  EXPECT_EQ(245768, detSpecMap.getNumberOfEntries());
+}

--- a/event_data/test/DetectorSpectrumMapDataTest.cpp
+++ b/event_data/test/DetectorSpectrumMapDataTest.cpp
@@ -40,7 +40,7 @@ TEST(DetectorSpectrumMapDataTest, create_message_buffer) {
       DetectorSpectrumMapData(testDataPath + "spectrum_gastubes_01.dat");
 
   std::string rawbuf;
-  EXPECT_NO_THROW(detSpecMap.getEventBufferPointer(rawbuf));
+  EXPECT_NO_THROW(detSpecMap.getBufferPointer(rawbuf));
 
   auto receivedMapData = DetectorSpectrumMapData();
   EXPECT_NO_THROW(receivedMapData.decodeMessage(

--- a/nexus_producer/CMakeLists.txt
+++ b/nexus_producer/CMakeLists.txt
@@ -28,7 +28,8 @@ target_link_libraries(eventPublisher_lib
 target_link_libraries(nexusPublisher_lib
         nexusFileReader_lib
         eventdata_lib
-        rundata_lib)
+        rundata_lib
+        detSpecMapData_lib)
 
 set(core_libraries
         eventdata_lib

--- a/nexus_producer/include/EventPublisher.h
+++ b/nexus_producer/include/EventPublisher.h
@@ -6,9 +6,12 @@
 class EventPublisher {
 public:
   virtual ~EventPublisher() {}
-  virtual void setUp(const std::string &broker, const std::string &topic, const std::string &runTopic) = 0;
+  virtual void setUp(const std::string &broker, const std::string &topic,
+                     const std::string &runTopic,
+                     const std::string &detSpecTopic) = 0;
   virtual void sendEventMessage(char *buf, size_t messageSize) = 0;
   virtual void sendRunMessage(char *buf, size_t messageSize) = 0;
+  virtual void sendDetSpecMessage(char *buf, size_t messageSize) = 0;
   virtual int64_t getCurrentOffset() = 0;
 };
 

--- a/nexus_producer/include/KafkaEventPublisher.h
+++ b/nexus_producer/include/KafkaEventPublisher.h
@@ -13,9 +13,12 @@ public:
       : m_compression(compression){};
   ~KafkaEventPublisher() { RdKafka::wait_destroyed(5000); };
 
-  void setUp(const std::string &broker_str, const std::string &topic_str, const std::string &runTopic_str) override;
+  void setUp(const std::string &broker_str, const std::string &topic_str,
+             const std::string &runTopic_str,
+             const std::string &detSpecTopic) override;
   void sendEventMessage(char *buf, size_t messageSize) override;
   void sendRunMessage(char *buf, size_t messageSize) override;
+  void sendDetSpecMessage(char *buf, size_t messageSize) override;
   int64_t getCurrentOffset() override;
 
 private:
@@ -27,6 +30,8 @@ private:
   std::shared_ptr<RdKafka::Topic> m_topic_ptr;
   std::shared_ptr<RdKafka::Producer> m_runProducer_ptr;
   std::shared_ptr<RdKafka::Topic> m_runTopic_ptr;
+  std::shared_ptr<RdKafka::Producer> m_detSpecProducer_ptr;
+  std::shared_ptr<RdKafka::Topic> m_detSpecTopic_ptr;
   std::string m_compression = "";
 
   // We require messages to be in order, therefore always publish to partition 0

--- a/nexus_producer/include/KafkaEventPublisher.h
+++ b/nexus_producer/include/KafkaEventPublisher.h
@@ -23,14 +23,11 @@ public:
 
 private:
   void sendMessage(char *buf, size_t messageSize,
-                   std::shared_ptr<RdKafka::Producer> producer,
                    std::shared_ptr<RdKafka::Topic> topic);
 
   std::shared_ptr<RdKafka::Producer> m_producer_ptr;
   std::shared_ptr<RdKafka::Topic> m_topic_ptr;
-  std::shared_ptr<RdKafka::Producer> m_runProducer_ptr;
   std::shared_ptr<RdKafka::Topic> m_runTopic_ptr;
-  std::shared_ptr<RdKafka::Producer> m_detSpecProducer_ptr;
   std::shared_ptr<RdKafka::Topic> m_detSpecTopic_ptr;
   std::string m_compression = "";
 

--- a/nexus_producer/include/MockEventPublisher.h
+++ b/nexus_producer/include/MockEventPublisher.h
@@ -6,9 +6,11 @@
 
 class MockEventPublisher : public EventPublisher {
 public:
-  MOCK_METHOD3(setUp,
-               void(const std::string &broker, const std::string &topic, const std::string &runTopic));
+  MOCK_METHOD4(setUp, void(const std::string &broker, const std::string &topic,
+                           const std::string &runTopic,
+                           const std::string &detSpecTopic));
   MOCK_METHOD2(sendRunMessage, void(char *buf, size_t messageSize));
+  MOCK_METHOD2(sendDetSpecMessage, void(char *buf, size_t messageSize));
   MOCK_METHOD2(sendEventMessage, void(char *buf, size_t messageSize));
   MOCK_METHOD0(getCurrentOffset, int64_t());
 };

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -5,6 +5,7 @@
 
 #include "../../event_data/include/EventData.h"
 #include "../../event_data/include/RunData.h"
+#include "../../event_data/include/DetectorSpectrumMapData.h"
 #include "../../nexus_file_reader/include/NexusFileReader.h"
 #include "EventPublisher.h"
 
@@ -13,11 +14,15 @@ public:
   NexusPublisher(std::shared_ptr<EventPublisher> publisher,
                  const std::string &brokerAddress,
                  const std::string &streamName, const std::string &runTopicName,
-                 const std::string &filename, const bool quietMode);
+                 const std::string &detSpecTopicName,
+                 const std::string &filename,
+                 const std::string &detSpecMapFilename, const bool quietMode);
   std::vector<std::shared_ptr<EventData>>
   createMessageData(hsize_t frameNumber, const int messagesPerFrame);
   int64_t createAndSendRunMessage(std::string &rawbuf, int runNumber);
+  int64_t createAndSendDetSpecMessage(std::string &rawbuf);
   std::shared_ptr<RunData> createRunMessageData(int runNumber);
+  std::shared_ptr<DetectorSpectrumMapData> createDetSpecMessageData();
   void streamData(const int messagesPerFrame, int runNumber, bool slow);
 
 private:
@@ -28,6 +33,7 @@ private:
   std::shared_ptr<EventPublisher> m_publisher;
   std::shared_ptr<NexusFileReader> m_fileReader;
   bool m_quietMode = false;
+  std::string m_detSpecMapFilename;
 };
 
 #endif // ISIS_NEXUS_STREAMER_NEXUSPUBLISHER_H

--- a/nexus_producer/src/KafkaEventPublisher.cpp
+++ b/nexus_producer/src/KafkaEventPublisher.cpp
@@ -49,39 +49,24 @@ void KafkaEventPublisher::setUp(const std::string &broker_str,
     exit(1);
   }
 
-  // Create run message producer
-  m_runProducer_ptr = std::shared_ptr<RdKafka::Producer>(
-      RdKafka::Producer::create(conf, error_str));
-  if (!m_runProducer_ptr.get()) {
-    std::cerr << "Failed to create producer: " << error_str << std::endl;
-    exit(1);
-  }
-
   // Create run topic handle
   m_runTopic_ptr = std::shared_ptr<RdKafka::Topic>(RdKafka::Topic::create(
-      m_runProducer_ptr.get(), runTopic_str, tconf, error_str));
+      m_producer_ptr.get(), runTopic_str, tconf, error_str));
   if (!m_runTopic_ptr.get()) {
     std::cerr << "Failed to create topic: " << error_str << std::endl;
     exit(1);
   }
 
-  // Create detSpec message producer
-  m_detSpecProducer_ptr = std::shared_ptr<RdKafka::Producer>(
-      RdKafka::Producer::create(conf, error_str));
-  if (!m_detSpecProducer_ptr.get()) {
-    std::cerr << "Failed to create producer: " << error_str << std::endl;
-    exit(1);
-  }
-
   // Create detSpec topic handle
   m_detSpecTopic_ptr = std::shared_ptr<RdKafka::Topic>(RdKafka::Topic::create(
-      m_runProducer_ptr.get(), detSpecTopic_str, tconf, error_str));
+      m_producer_ptr.get(), detSpecTopic_str, tconf, error_str));
   if (!m_detSpecTopic_ptr.get()) {
     std::cerr << "Failed to create topic: " << error_str << std::endl;
     exit(1);
   }
 
-  // This ensures everything is ready when we need to query offset information later
+  // This ensures everything is ready when we need to query offset information
+  // later
   m_producer_ptr->poll(1000);
 }
 
@@ -92,26 +77,25 @@ void KafkaEventPublisher::setUp(const std::string &broker_str,
  * @param messageSize - the size of the message in bytes
  */
 void KafkaEventPublisher::sendEventMessage(char *buf, size_t messageSize) {
-  sendMessage(buf, messageSize, m_producer_ptr, m_topic_ptr);
+  sendMessage(buf, messageSize, m_topic_ptr);
 }
 
 void KafkaEventPublisher::sendRunMessage(char *buf, size_t messageSize) {
-  sendMessage(buf, messageSize, m_runProducer_ptr, m_runTopic_ptr);
+  sendMessage(buf, messageSize, m_runTopic_ptr);
 }
 
 void KafkaEventPublisher::sendDetSpecMessage(char *buf, size_t messageSize) {
-  sendMessage(buf, messageSize, m_detSpecProducer_ptr, m_detSpecTopic_ptr);
+  sendMessage(buf, messageSize, m_detSpecTopic_ptr);
 }
 
-void KafkaEventPublisher::sendMessage(
-    char *buf, size_t messageSize, std::shared_ptr<RdKafka::Producer> producer,
-    std::shared_ptr<RdKafka::Topic> topic) {
+void KafkaEventPublisher::sendMessage(char *buf, size_t messageSize,
+                                      std::shared_ptr<RdKafka::Topic> topic) {
   RdKafka::ErrorCode resp;
   do {
 
-    resp = producer->produce(topic.get(), m_partitionNumber,
-                             RdKafka::Producer::RK_MSG_COPY, buf, messageSize,
-                             NULL, NULL);
+    resp = m_producer_ptr->produce(topic.get(), m_partitionNumber,
+                                   RdKafka::Producer::RK_MSG_COPY, buf,
+                                   messageSize, NULL, NULL);
 
     if (resp != RdKafka::ERR_NO_ERROR) {
       if (resp != RdKafka::ERR__QUEUE_FULL) {
@@ -122,9 +106,9 @@ void KafkaEventPublisher::sendMessage(
       // This blocking poll call should give Kafka some time for the problem to
       // be resolved
       // for example for messages to leave the queue if it is full
-      producer->poll(1000);
+      m_producer_ptr->poll(1000);
     } else {
-      producer->poll(0);
+      m_producer_ptr->poll(0);
     }
   } while (resp == RdKafka::ERR__QUEUE_FULL);
 }

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -14,19 +14,25 @@ int main(int argc, char **argv) {
 
   int opt;
   std::string filename;
+  std::string detSpecFilename;
   std::string broker = "sakura";
   std::string topic = "test_event_topic";
   std::string runTopic = "test_run_topic";
+  std::string detSpecTopic = "test_det_spec_topic";
   std::string compression = "";
   bool slow = false;
   bool quietMode = false;
   int messagesPerFrame = 1;
 
-  while ((opt = getopt(argc, argv, "f:b:t:c:m:r:sq")) != -1) {
+  while ((opt = getopt(argc, argv, "f:d:b:t:c:m:r:a:sq")) != -1) {
     switch (opt) {
 
     case 'f':
       filename = optarg;
+      break;
+
+    case 'd':
+      detSpecFilename = optarg;
       break;
 
     case 'b':
@@ -49,6 +55,10 @@ int main(int argc, char **argv) {
       runTopic = optarg;
       break;
 
+    case 'a':
+      detSpecTopic = optarg;
+      break;
+
     case 's':
       slow = true;
       break;
@@ -62,16 +72,21 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (filename.empty()) {
+  if (filename.empty() || detSpecFilename.empty()) {
   usage:
     fprintf(stderr,
             "Usage:\n"
             "%s -f <filepath>\n"
-            "[-b <host>]    Specify broker IP address or hostname, default is 'sakura'\n"
+            "-d <det_spec_map_filepath>\n"
+            "[-b <host>]    Specify broker IP address or hostname, default is "
+            "'sakura'\n"
             "[-t <event_topic_name>]    Specify name of event data topic to "
             "publish to, default is 'test_event_topic'\n"
             "[-r <run_topic_name>]    Specify name of run data topic to "
             "publish to, default is 'test_run_topic'\n"
+            "[-a <det_spec_topic_name>]    Specify name of detector-spectra "
+            "map topic to "
+            "publish to, default is 'test_det_spec_topic'\n"
             "[-m <messages_per_frame>]   Specify number of messages per frame, "
             "default is '1'\n"
             "[-s]    Slow mode, publishes data at approx realistic rate of 10 "
@@ -84,7 +99,8 @@ int main(int argc, char **argv) {
 
   auto publisher = std::make_shared<KafkaEventPublisher>(compression);
   int runNumber = 1;
-  NexusPublisher streamer(publisher, broker, topic, runTopic, filename, quietMode);
+  NexusPublisher streamer(publisher, broker, topic, runTopic, detSpecTopic,
+                          filename, detSpecFilename, quietMode);
 
   // Publish the same data repeatedly, with incrementing run numbers
   while (true) {


### PR DESCRIPTION
Closes #9 

Detector-spectrum mapping is read from a specified file and sent to a specified, separate topic. There are new optional arguments to support this. New functionality is covered by new unit tests.
