### PR TITLE
Add travis build job using trusty's default gcc version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
 #      install:
 #          - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.8" CC="clang-3.8"; fi
     - compiler: gcc
+      env: COMPILER=g++
+    - compiler: gcc
       addons:
         apt:
           sources:


### PR DESCRIPTION
This should avoid creating compilation problems for Martyn.
