### PR TITLE
Specify max events per message instead of messages per frame

### DIFF
--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -21,6 +21,7 @@ public:
   size_t getNumberOfFrames() { return m_numberOfFrames; };
   hsize_t getNumberOfEventsInFrame(hsize_t frameNumber);
   double getFrameTime(hsize_t frameNumber);
+  std::vector<int> getFramePartsPerFrame(int maxEventsPerMessage);
   int64_t getRunStartTime();
   std::string getInstrumentName();
 

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -1,8 +1,9 @@
 #include "../include/NexusFileReader.h"
-#include <iostream>
+#include <cmath>
 #include <ctime>
-#include <sstream>
 #include <iomanip>
+#include <iostream>
+#include <sstream>
 
 using namespace H5;
 
@@ -66,7 +67,8 @@ int64_t NexusFileReader::getRunStartTime() {
   return convertStringToUnixTime(startTime);
 }
 
-int64_t NexusFileReader::convertStringToUnixTime(const std::string &timeString) {
+int64_t
+NexusFileReader::convertStringToUnixTime(const std::string &timeString) {
   std::tm tmb = {};
 #if defined(__GNUC__) && __GNUC__ >= 5
   std::istringstream ss(timeString);
@@ -244,4 +246,16 @@ bool NexusFileReader::getEventTofs(std::vector<float> &tofs,
   dataset.read(tofs.data(), PredType::NATIVE_FLOAT, memspace, dataspace);
 
   return true;
+}
+
+std::vector<int>
+NexusFileReader::getFramePartsPerFrame(int maxEventsPerMessage) {
+  std::vector<int> framePartsPerFrame;
+  framePartsPerFrame.resize(m_numberOfFrames);
+  for (hsize_t frameNumber = 0; frameNumber < m_numberOfFrames; frameNumber++) {
+    framePartsPerFrame[frameNumber] = static_cast<int>(
+        std::ceil(static_cast<float>(getNumberOfEventsInFrame(frameNumber)) /
+                  static_cast<float>(maxEventsPerMessage)));
+  }
+  return framePartsPerFrame;
 }

--- a/nexus_file_reader/test/NexusFileReaderTest.cpp
+++ b/nexus_file_reader/test/NexusFileReaderTest.cpp
@@ -109,3 +109,10 @@ TEST(NexusFileReaderTest, get_instrument_name) {
   auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
   EXPECT_EQ("SANS2D", fileReader.getInstrumentName());
 }
+
+TEST(NexusFileReaderTest, get_frame_parts_per_frame) {
+  extern std::string testDataPath;
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5");
+  auto framePartsPerFrame = fileReader.getFramePartsPerFrame(200);
+  EXPECT_EQ(4, framePartsPerFrame[0]);
+}

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -23,7 +23,7 @@ public:
   int64_t createAndSendDetSpecMessage(std::string &rawbuf);
   std::shared_ptr<RunData> createRunMessageData(int runNumber);
   std::shared_ptr<DetectorSpectrumMapData> createDetSpecMessageData();
-  void streamData(const int messagesPerFrame, int runNumber, bool slow);
+  void streamData(const int maxEventsPerFramePart, int runNumber, bool slow);
 
 private:
   int64_t createAndSendMessage(std::string &rawbuf, size_t frameNumber,

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -142,7 +142,7 @@ void NexusPublisher::streamData(const int messagesPerFrame, int runNumber,
     reportProgress(static_cast<float>(frameNumber) /
                    static_cast<float>(numberOfFrames));
 
-    // Publish messages at roughly realistic messsage rate (~10 frames per
+    // Publish messages at roughly realistic message rate (~10 frames per
     // second)
     if (slow) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -125,20 +125,21 @@ NexusPublisher::createDetSpecMessageData() {
 /**
  * Start streaming all the data from the file
  */
-void NexusPublisher::streamData(const int messagesPerFrame, int runNumber,
+void NexusPublisher::streamData(const int maxEventsPerFramePart, int runNumber,
                                 bool slow) {
   std::string rawbuf;
   // frame numbers run from 0 to numberOfFrames-1
   reportProgress(0.0);
   int64_t totalBytesSent = 0;
   const auto numberOfFrames = m_fileReader->getNumberOfFrames();
+  auto framePartsPerFrame = m_fileReader->getFramePartsPerFrame(maxEventsPerFramePart);
 
   totalBytesSent += createAndSendRunMessage(rawbuf, runNumber);
   totalBytesSent += createAndSendDetSpecMessage(rawbuf);
 
   for (size_t frameNumber = 0; frameNumber < numberOfFrames; frameNumber++) {
     totalBytesSent +=
-        createAndSendMessage(rawbuf, frameNumber, messagesPerFrame);
+        createAndSendMessage(rawbuf, frameNumber, framePartsPerFrame[frameNumber]);
     reportProgress(static_cast<float>(frameNumber) /
                    static_cast<float>(numberOfFrames));
 
@@ -151,10 +152,7 @@ void NexusPublisher::streamData(const int messagesPerFrame, int runNumber,
   reportProgress(1.0);
   std::cout << std::endl
             << "Frames sent: " << m_fileReader->getNumberOfFrames() << std::endl
-            << "Bytes sent: " << totalBytesSent << std::endl
-            << "Average message size: "
-            << totalBytesSent / (messagesPerFrame * numberOfFrames * 1000)
-            << " kB" << std::endl;
+            << "Bytes sent: " << totalBytesSent << std::endl;
 }
 
 /**

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
   std::string compression = "";
   bool slow = false;
   bool quietMode = false;
-  int messagesPerFrame = 1;
+  int maxEventsPerFramePart = 200;
 
   while ((opt = getopt(argc, argv, "f:d:b:t:c:m:r:a:sq")) != -1) {
     switch (opt) {
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
       break;
 
     case 'm':
-      messagesPerFrame = std::stoi(optarg);
+      maxEventsPerFramePart = std::stoi(optarg);
       break;
 
     case 'r':
@@ -87,8 +87,8 @@ int main(int argc, char **argv) {
             "[-a <det_spec_topic_name>]    Specify name of detector-spectra "
             "map topic to "
             "publish to, default is 'test_det_spec_topic'\n"
-            "[-m <messages_per_frame>]   Specify number of messages per frame, "
-            "default is '1'\n"
+            "[-m <max_events_per_message>]   Maximum number of events to send "
+            "in a single message, default is 200\n"
             "[-s]    Slow mode, publishes data at approx realistic rate of 10 "
             "frames per second\n"
             "[-q]    Quiet mode, makes publisher less chatty on stdout\n"
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
 
   // Publish the same data repeatedly, with incrementing run numbers
   while (true) {
-    streamer.streamData(messagesPerFrame, runNumber, slow);
+    streamer.streamData(maxEventsPerFramePart, runNumber, slow);
     runNumber++;
   }
 

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -126,13 +126,12 @@ TEST_F(NexusPublisherTest, test_stream_data) {
   auto publisher = std::make_shared<MockEventPublisher>();
 
   const int numberOfFrames = 300;
-  const int messagesPerFrame = 1;
+  const int maxEventsPerFramePart = 1000000;
 
   EXPECT_CALL(*publisher.get(), setUp(broker, topic, runTopic, detSpecTopic))
       .Times(AtLeast(1));
   EXPECT_CALL(*publisher.get(), sendEventMessage(_, _))
-      .Times(numberOfFrames * messagesPerFrame +
-             1); // +1 for run metadata message
+      .Times(numberOfFrames + 1); // +1 for run data message
   EXPECT_CALL(*publisher.get(), sendRunMessage(_, _)).Times(1);
   EXPECT_CALL(*publisher.get(), sendDetSpecMessage(_, _)).Times(1);
   EXPECT_CALL(*publisher.get(), getCurrentOffset()).Times(1);
@@ -140,7 +139,7 @@ TEST_F(NexusPublisherTest, test_stream_data) {
   NexusPublisher streamer(publisher, broker, topic, runTopic, detSpecTopic,
                           testDataPath + "SANS_test_reduced.hdf5",
                           testDataPath + "spectrum_gastubes_01.dat", true);
-  EXPECT_NO_THROW(streamer.streamData(messagesPerFrame, 1, false));
+  EXPECT_NO_THROW(streamer.streamData(maxEventsPerFramePart, 1, false));
 }
 
 TEST_F(NexusPublisherTest, test_stream_data_multiple_messages_per_frame) {
@@ -154,14 +153,12 @@ TEST_F(NexusPublisherTest, test_stream_data_multiple_messages_per_frame) {
 
   auto publisher = std::make_shared<MockEventPublisher>();
 
-  const int numberOfFrames = 300;
-  const int messagesPerFrame = 10;
+  const int maxEventsPerFramePart = 200;
 
   EXPECT_CALL(*publisher.get(), setUp(broker, topic, runTopic, detSpecTopic))
       .Times(AtLeast(1));
   EXPECT_CALL(*publisher.get(), sendEventMessage(_, _))
-      .Times(numberOfFrames * messagesPerFrame +
-             1); // +1 for run metadata message
+      .Times(1292);
   EXPECT_CALL(*publisher.get(), sendRunMessage(_, _)).Times(1);
   EXPECT_CALL(*publisher.get(), sendDetSpecMessage(_, _)).Times(1);
   EXPECT_CALL(*publisher.get(), getCurrentOffset()).Times(1);
@@ -169,7 +166,7 @@ TEST_F(NexusPublisherTest, test_stream_data_multiple_messages_per_frame) {
   NexusPublisher streamer(publisher, broker, topic, runTopic, detSpecTopic,
                           testDataPath + "SANS_test_reduced.hdf5",
                           testDataPath + "spectrum_gastubes_01.dat", true);
-  EXPECT_NO_THROW(streamer.streamData(messagesPerFrame, 1, false));
+  EXPECT_NO_THROW(streamer.streamData(maxEventsPerFramePart, 1, false));
 }
 
 TEST_F(NexusPublisherTest, test_create_run_message_data) {


### PR DESCRIPTION
Closes #6 

Specify max events per message instead of messages per frame.
The default is 200 events per message but it can be specified via optarg.
