### PR TITLE
Add message id to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ main_nexusPublisher -f <filepath>    Full file path of nexus file to stream
 [-t <event_topic_name>]    Name of event data topic to publish to, default is 'test_event_topic'
 [-r <run_topic_name>]    Name of run data topic to publish to, default is 'test_run_topic'
 [-a <det_spec_topic_name>]    Name of detector-spectra map topic to publish to, default is 'test_det_spec_topic'
-[-m <messages_per_frame>]   Number of messages per frame to use, default is '1'
+[-m <events_per_message>]   Maximum number of events to send in a single message, default is '200'
 [-s]    Slow mode, publishes data at approx realistic rate of 10 frames per second
 [-q]    Quiet mode, makes publisher less chatty on stdout
+[-u]    Random mode, serve messages within each frame in a random order, for testing purposes
 ```
 
 ## Dependencies

--- a/event_data/include/EventData.h
+++ b/event_data/include/EventData.h
@@ -7,6 +7,8 @@
 #include "SampleEnvironmentEvent.h"
 #include "event_schema_generated.h"
 
+uint64_t getMessageID(const std::string &rawbuf);
+
 class EventData {
 
 public:
@@ -43,7 +45,8 @@ public:
   }
   size_t getBufferSize() { return m_bufferSize; }
 
-  flatbuffers::unique_ptr_t getBufferPointer(std::string &buffer);
+  flatbuffers::unique_ptr_t getBufferPointer(std::string &buffer,
+                                             uint64_t messageID);
 
   void addSEEvent(std::shared_ptr<SampleEnvironmentEvent> sEEvent) {
     m_sampleEnvironmentEvents.push_back(sEEvent);
@@ -66,7 +69,8 @@ private:
   std::vector<std::shared_ptr<SampleEnvironmentEvent>>
       m_sampleEnvironmentEvents = {};
   void decodeSampleEnvironmentEvents(
-      const flatbuffers::Vector<flatbuffers::Offset<ISISDAE::SEEvent>> *sEEventVector);
+      const flatbuffers::Vector<flatbuffers::Offset<ISISDAE::SEEvent>>
+          *sEEventVector);
 };
 
 #endif // ISIS_NEXUS_STREAMER_EVENTDATA_H

--- a/event_data/include/RunData.h
+++ b/event_data/include/RunData.h
@@ -7,7 +7,8 @@ class RunData {
 
 public:
   bool decodeMessage(const uint8_t *buf);
-  flatbuffers::unique_ptr_t getEventBufferPointer(std::string &buffer);
+  flatbuffers::unique_ptr_t getEventBufferPointer(std::string &buffer,
+                                                  uint64_t messageID);
   flatbuffers::unique_ptr_t getRunBufferPointer(std::string &buffer);
 
   void setRunNumber(int32_t runNumber) { m_runNumber = runNumber; }

--- a/event_data/include/event_schema_generated.h
+++ b/event_data/include/event_schema_generated.h
@@ -372,15 +372,18 @@ inline flatbuffers::Offset<FramePart> CreateFramePart(flatbuffers::FlatBufferBui
 struct EventMessage FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum {
     VT_MESSAGE_TYPE = 4,
-    VT_MESSAGE = 6
+    VT_MESSAGE = 6,
+    VT_ID = 8
   };
   MessageTypes message_type() const { return static_cast<MessageTypes>(GetField<uint8_t>(VT_MESSAGE_TYPE, 0)); }
   const void *message() const { return GetPointer<const void *>(VT_MESSAGE); }
+  uint64_t id() const { return GetField<uint64_t>(VT_ID, 0); }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<uint8_t>(verifier, VT_MESSAGE_TYPE) &&
            VerifyField<flatbuffers::uoffset_t>(verifier, VT_MESSAGE) &&
            VerifyMessageTypes(verifier, message(), message_type()) &&
+           VerifyField<uint64_t>(verifier, VT_ID) &&
            verifier.EndTable();
   }
 };
@@ -390,18 +393,21 @@ struct EventMessageBuilder {
   flatbuffers::uoffset_t start_;
   void add_message_type(MessageTypes message_type) { fbb_.AddElement<uint8_t>(EventMessage::VT_MESSAGE_TYPE, static_cast<uint8_t>(message_type), 0); }
   void add_message(flatbuffers::Offset<void> message) { fbb_.AddOffset(EventMessage::VT_MESSAGE, message); }
+  void add_id(uint64_t id) { fbb_.AddElement<uint64_t>(EventMessage::VT_ID, id, 0); }
   EventMessageBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb) { start_ = fbb_.StartTable(); }
   EventMessageBuilder &operator=(const EventMessageBuilder &);
   flatbuffers::Offset<EventMessage> Finish() {
-    auto o = flatbuffers::Offset<EventMessage>(fbb_.EndTable(start_, 2));
+    auto o = flatbuffers::Offset<EventMessage>(fbb_.EndTable(start_, 3));
     return o;
   }
 };
 
 inline flatbuffers::Offset<EventMessage> CreateEventMessage(flatbuffers::FlatBufferBuilder &_fbb,
    MessageTypes message_type = MessageTypes_NONE,
-   flatbuffers::Offset<void> message = 0) {
+   flatbuffers::Offset<void> message = 0,
+   uint64_t id = 0) {
   EventMessageBuilder builder_(_fbb);
+  builder_.add_id(id);
   builder_.add_message(message);
   builder_.add_message_type(message_type);
   return builder_.Finish();

--- a/event_data/src/EventData.cpp
+++ b/event_data/src/EventData.cpp
@@ -5,6 +5,12 @@
 #include <SampleEnvironmentEventString.h>
 #include <iostream>
 
+uint64_t getMessageID(const std::string &rawbuf) {
+  auto buf = reinterpret_cast<const uint8_t *>(rawbuf.c_str());
+  auto messageData = ISISDAE::GetEventMessage(buf);
+  return messageData->id();
+}
+
 void EventData::decodeSampleEnvironmentEvents(
     const flatbuffers::Vector<flatbuffers::Offset<ISISDAE::SEEvent>>
         *sEEventVector) {
@@ -66,7 +72,8 @@ bool EventData::decodeMessage(const uint8_t *buf) {
   return false; // this is not an EventData message
 }
 
-flatbuffers::unique_ptr_t EventData::getBufferPointer(std::string &buffer) {
+flatbuffers::unique_ptr_t EventData::getBufferPointer(std::string &buffer,
+                                                      uint64_t messageID) {
   flatbuffers::FlatBufferBuilder builder;
 
   std::vector<flatbuffers::Offset<ISISDAE::SEEvent>> sEEventsVector;
@@ -84,8 +91,9 @@ flatbuffers::unique_ptr_t EventData::getBufferPointer(std::string &buffer) {
       m_protonCharge, m_period, m_endOfFrame, m_endOfRun, messageNEvents,
       messageSEEvents);
 
-  auto messageFlatbuf = ISISDAE::CreateEventMessage(
-      builder, ISISDAE::MessageTypes_FramePart, messageFramePart.Union());
+  auto messageFlatbuf =
+      ISISDAE::CreateEventMessage(builder, ISISDAE::MessageTypes_FramePart,
+                                  messageFramePart.Union(), messageID);
   builder.Finish(messageFlatbuf);
 
   auto bufferpointer =

--- a/event_data/src/RunData.cpp
+++ b/event_data/src/RunData.cpp
@@ -33,7 +33,8 @@ bool RunData::decodeMessage(const uint8_t *buf) {
   return false; // this is not a RunData message
 }
 
-flatbuffers::unique_ptr_t RunData::getEventBufferPointer(std::string &buffer) {
+flatbuffers::unique_ptr_t RunData::getEventBufferPointer(std::string &buffer,
+                                                         uint64_t messageID) {
   flatbuffers::FlatBufferBuilder builder;
 
   auto instrumentName = builder.CreateString(m_instrumentName);
@@ -41,7 +42,7 @@ flatbuffers::unique_ptr_t RunData::getEventBufferPointer(std::string &buffer) {
       builder, m_startTime, m_runNumber, instrumentName, m_streamOffset);
 
   auto messageFlatbuf = ISISDAE::CreateEventMessage(
-      builder, ISISDAE::MessageTypes_RunInfo, messageRunInfo.Union());
+      builder, ISISDAE::MessageTypes_RunInfo, messageRunInfo.Union(), messageID);
   builder.Finish(messageFlatbuf);
 
   auto bufferpointer =

--- a/event_data/src/event_schema.fbs
+++ b/event_data/src/event_schema.fbs
@@ -56,6 +56,7 @@ union MessageTypes { FramePart, RunInfo }
 
 table EventMessage {
     message : MessageTypes;
+    id : ulong;
 }
 
 root_type EventMessage;

--- a/event_data/test/EventDataTest.cpp
+++ b/event_data/test/EventDataTest.cpp
@@ -35,7 +35,7 @@ TEST(EventDataTest, get_buffer_pointer) {
   EXPECT_NO_THROW(events.setPeriod(period));
 
   std::string rawbuf;
-  EXPECT_NO_THROW(events.getBufferPointer(rawbuf));
+  EXPECT_NO_THROW(events.getBufferPointer(rawbuf, 0));
 
   auto receivedEventData = EventData();
   EXPECT_TRUE(receivedEventData.decodeMessage(
@@ -61,7 +61,7 @@ TEST(EventDataTest, get_buffer_size) {
   events.setTof(tofs);
 
   std::string rawbuf;
-  EXPECT_NO_THROW(events.getBufferPointer(rawbuf));
+  EXPECT_NO_THROW(events.getBufferPointer(rawbuf, 0));
   EXPECT_TRUE(events.getBufferSize() > 0);
 }
 
@@ -95,7 +95,7 @@ TEST(EventDataTest, add_sample_environment_event) {
   EXPECT_NO_THROW(events.addSEEvent(sEEventString));
 
   std::string rawbuf;
-  EXPECT_NO_THROW(events.getBufferPointer(rawbuf));
+  EXPECT_NO_THROW(events.getBufferPointer(rawbuf, 0));
   auto receivedEventData = EventData();
   EXPECT_TRUE(receivedEventData.decodeMessage(
       reinterpret_cast<const uint8_t *>(rawbuf.c_str())));

--- a/event_data/test/EventDataTest.cpp
+++ b/event_data/test/EventDataTest.cpp
@@ -62,7 +62,7 @@ TEST(EventDataTest, get_buffer_size) {
 
   std::string rawbuf;
   EXPECT_NO_THROW(events.getBufferPointer(rawbuf));
-  EXPECT_EQ(128, events.getBufferSize());
+  EXPECT_TRUE(events.getBufferSize() > 0);
 }
 
 TEST(EventDataTest, add_sample_environment_event) {

--- a/event_data/test/RunDataTest.cpp
+++ b/event_data/test/RunDataTest.cpp
@@ -48,7 +48,7 @@ TEST(RunDataTest, encode_and_decode_RunData) {
   EXPECT_NO_THROW(rundata.setStartTime("2016-08-11T08:50:18"));
 
   std::string rawbuf;
-  EXPECT_NO_THROW(rundata.getEventBufferPointer(rawbuf));
+  EXPECT_NO_THROW(rundata.getEventBufferPointer(rawbuf, 0));
 
   auto receivedRunData = RunData();
   EXPECT_TRUE(receivedRunData.decodeMessage(

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -37,6 +37,7 @@ private:
   bool m_quietMode = false;
   std::string m_detSpecMapFilename;
   std::unordered_map<hsize_t, sEEventVector> m_sEEventMap;
+  uint64_t m_messageID = 0;
 };
 
 #endif // ISIS_NEXUS_STREAMER_NEXUSPUBLISHER_H

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -16,7 +16,8 @@ public:
                  const std::string &streamName, const std::string &runTopicName,
                  const std::string &detSpecTopicName,
                  const std::string &filename,
-                 const std::string &detSpecMapFilename, const bool quietMode);
+                 const std::string &detSpecMapFilename, const bool quietMode,
+                 const bool randomMode);
   std::vector<std::shared_ptr<EventData>>
   createMessageData(hsize_t frameNumber, const int messagesPerFrame);
   int64_t createAndSendRunMessage(std::string &rawbuf, int runNumber);
@@ -38,6 +39,7 @@ private:
   std::string m_detSpecMapFilename;
   std::unordered_map<hsize_t, sEEventVector> m_sEEventMap;
   uint64_t m_messageID = 0;
+  bool m_randomMode;
 };
 
 #endif // ISIS_NEXUS_STREAMER_NEXUSPUBLISHER_H

--- a/nexus_producer/src/KafkaEventPublisher.cpp
+++ b/nexus_producer/src/KafkaEventPublisher.cpp
@@ -17,8 +17,8 @@ void KafkaEventPublisher::setUp(const std::string &broker_str,
 
   std::string error_str;
 
-  RdKafka::Conf *conf = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
-  RdKafka::Conf *tconf = RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC);
+  auto conf = std::unique_ptr<RdKafka::Conf>(RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL));
+  auto tconf = std::unique_ptr<RdKafka::Conf>(RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC));
 
   conf->set("metadata.broker.list", broker_str, error_str);
   conf->set("message.max.bytes", "10000000", error_str);
@@ -35,7 +35,7 @@ void KafkaEventPublisher::setUp(const std::string &broker_str,
 
   // Create producer
   m_producer_ptr = std::shared_ptr<RdKafka::Producer>(
-      RdKafka::Producer::create(conf, error_str));
+      RdKafka::Producer::create(conf.get(), error_str));
   if (!m_producer_ptr.get()) {
     std::cerr << "Failed to create producer: " << error_str << std::endl;
     exit(1);
@@ -43,7 +43,7 @@ void KafkaEventPublisher::setUp(const std::string &broker_str,
 
   // Create topic handle
   m_topic_ptr = std::shared_ptr<RdKafka::Topic>(RdKafka::Topic::create(
-      m_producer_ptr.get(), topic_str, tconf, error_str));
+      m_producer_ptr.get(), topic_str, tconf.get(), error_str));
   if (!m_topic_ptr.get()) {
     std::cerr << "Failed to create topic: " << error_str << std::endl;
     exit(1);
@@ -51,7 +51,7 @@ void KafkaEventPublisher::setUp(const std::string &broker_str,
 
   // Create run topic handle
   m_runTopic_ptr = std::shared_ptr<RdKafka::Topic>(RdKafka::Topic::create(
-      m_producer_ptr.get(), runTopic_str, tconf, error_str));
+      m_producer_ptr.get(), runTopic_str, tconf.get(), error_str));
   if (!m_runTopic_ptr.get()) {
     std::cerr << "Failed to create topic: " << error_str << std::endl;
     exit(1);
@@ -59,7 +59,7 @@ void KafkaEventPublisher::setUp(const std::string &broker_str,
 
   // Create detSpec topic handle
   m_detSpecTopic_ptr = std::shared_ptr<RdKafka::Topic>(RdKafka::Topic::create(
-      m_producer_ptr.get(), detSpecTopic_str, tconf, error_str));
+      m_producer_ptr.get(), detSpecTopic_str, tconf.get(), error_str));
   if (!m_detSpecTopic_ptr.get()) {
     std::cerr << "Failed to create topic: " << error_str << std::endl;
     exit(1);

--- a/nexus_producer/src/KafkaEventPublisher.cpp
+++ b/nexus_producer/src/KafkaEventPublisher.cpp
@@ -22,6 +22,10 @@ void KafkaEventPublisher::setUp(const std::string &broker_str,
 
   conf->set("metadata.broker.list", broker_str, error_str);
   conf->set("message.send.max.retries", "3", error_str);
+  conf->set("message.max.bytes", "10000000", error_str);
+  conf->set("fetch.message.max.bytes", "10000000", error_str);
+  conf->set("replica.fetch.max.bytes", "10000000", error_str);
+
   if (!m_compression.empty()) {
     if (conf->set("compression.codec", m_compression, error_str) !=
         RdKafka::Conf::CONF_OK) {

--- a/nexus_producer/src/KafkaEventPublisher.cpp
+++ b/nexus_producer/src/KafkaEventPublisher.cpp
@@ -21,9 +21,7 @@ void KafkaEventPublisher::setUp(const std::string &broker_str,
   auto tconf = std::unique_ptr<RdKafka::Conf>(RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC));
 
   conf->set("metadata.broker.list", broker_str, error_str);
-  conf->set("message.max.bytes", "10000000", error_str);
-  conf->set("fetch.message.max.bytes", "10000000", error_str);
-  conf->set("replica.fetch.max.bytes", "10000000", error_str);
+  conf->set("message.send.max.retries", "3", error_str);
   if (!m_compression.empty()) {
     if (conf->set("compression.codec", m_compression, error_str) !=
         RdKafka::Conf::CONF_OK) {

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -181,10 +181,11 @@ int64_t NexusPublisher::createAndSendMessage(std::string &rawbuf,
   auto messageData = createMessageData(frameNumber, messagesPerFrame);
   int64_t dataSize = 0;
   for (const auto &message : messageData) {
-    auto buffer_uptr = message->getBufferPointer(rawbuf);
+    auto buffer_uptr = message->getBufferPointer(rawbuf, m_messageID);
     m_publisher->sendEventMessage(reinterpret_cast<char *>(buffer_uptr.get()),
                                   message->getBufferSize());
     dataSize += rawbuf.size();
+    m_messageID++;
   }
   return dataSize;
 }

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -19,14 +19,18 @@
  * @return - a NeXusPublisher object, call streamData() on it to start streaming
  * data
  */
-NexusPublisher::NexusPublisher(
-    std::shared_ptr<EventPublisher> publisher, const std::string &brokerAddress,
-    const std::string &streamName, const std::string &runTopicName,
-    const std::string &detSpecTopicName, const std::string &filename,
-    const std::string &detSpecMapFilename, const bool quietMode)
+NexusPublisher::NexusPublisher(std::shared_ptr<EventPublisher> publisher,
+                               const std::string &brokerAddress,
+                               const std::string &streamName,
+                               const std::string &runTopicName,
+                               const std::string &detSpecTopicName,
+                               const std::string &filename,
+                               const std::string &detSpecMapFilename,
+                               const bool quietMode, const bool randomMode)
     : m_publisher(publisher),
       m_fileReader(std::make_shared<NexusFileReader>(filename)),
-      m_quietMode(quietMode), m_detSpecMapFilename(detSpecMapFilename) {
+      m_quietMode(quietMode), m_randomMode(randomMode),
+      m_detSpecMapFilename(detSpecMapFilename) {
   publisher->setUp(brokerAddress, streamName, runTopicName, detSpecTopicName);
   m_sEEventMap = m_fileReader->getSEEventMap();
 }
@@ -141,7 +145,6 @@ void NexusPublisher::streamData(const int maxEventsPerFramePart, int runNumber,
                                 bool slow) {
   std::string rawbuf;
   // frame numbers run from 0 to numberOfFrames-1
-  reportProgress(0.0);
   int64_t totalBytesSent = 0;
   const auto numberOfFrames = m_fileReader->getNumberOfFrames();
   auto framePartsPerFrame =
@@ -179,14 +182,22 @@ int64_t NexusPublisher::createAndSendMessage(std::string &rawbuf,
                                              size_t frameNumber,
                                              const int messagesPerFrame) {
   auto messageData = createMessageData(frameNumber, messagesPerFrame);
-  int64_t dataSize = 0;
-  for (const auto &message : messageData) {
-    auto buffer_uptr = message->getBufferPointer(rawbuf, m_messageID);
-    m_publisher->sendEventMessage(reinterpret_cast<char *>(buffer_uptr.get()),
-                                  message->getBufferSize());
-    dataSize += rawbuf.size();
-    m_messageID++;
+  std::vector<int> indexes;
+  indexes.reserve(messageData.size());
+  for (int i = 0; i < messageData.size(); ++i)
+    indexes.push_back(i);
+  if (m_randomMode && indexes.size() > 1) {
+    std::random_shuffle(indexes.begin() + 1, indexes.end());
   }
+  int64_t dataSize = 0;
+  for (const auto &index : indexes) {
+    auto buffer_uptr =
+        messageData[index]->getBufferPointer(rawbuf, m_messageID + index);
+    m_publisher->sendEventMessage(reinterpret_cast<char *>(buffer_uptr.get()),
+                                  messageData[index]->getBufferSize());
+    dataSize += rawbuf.size();
+  }
+  m_messageID += indexes.size();
   return dataSize;
 }
 

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -201,7 +201,8 @@ int64_t NexusPublisher::createAndSendRunMessage(std::string &rawbuf,
                                                 int runNumber) {
   auto messageData = createRunMessageData(runNumber);
   messageData->setStreamOffset(m_publisher->getCurrentOffset());
-  auto buffer_uptr = messageData->getEventBufferPointer(rawbuf);
+  auto buffer_uptr = messageData->getEventBufferPointer(rawbuf, m_messageID);
+  m_messageID++;
   // publish to both topics
   m_publisher->sendEventMessage(reinterpret_cast<char *>(buffer_uptr.get()),
                                 messageData->getBufferSize());

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -22,9 +22,10 @@ int main(int argc, char **argv) {
   std::string compression = "";
   bool slow = false;
   bool quietMode = false;
+  bool randomMode = false;
   int maxEventsPerFramePart = 200;
 
-  while ((opt = getopt(argc, argv, "f:d:b:t:c:m:r:a:sq")) != -1) {
+  while ((opt = getopt(argc, argv, "f:d:b:t:c:m:r:a:squ")) != -1) {
     switch (opt) {
 
     case 'f':
@@ -67,6 +68,10 @@ int main(int argc, char **argv) {
       quietMode = true;
       break;
 
+    case 'u':
+      randomMode = true;
+      break;
+
     default:
       goto usage;
     }
@@ -93,6 +98,8 @@ int main(int argc, char **argv) {
             "[-s]    Slow mode, publishes data at approx realistic rate of 10 "
             "frames per second\n"
             "[-q]    Quiet mode, makes publisher less chatty on stdout\n"
+            "[-u]    Random mode, serve messages within each frame in a random "
+            "order\n"
             "\n",
             argv[0]);
     exit(1);
@@ -101,7 +108,7 @@ int main(int argc, char **argv) {
   auto publisher = std::make_shared<KafkaEventPublisher>(compression);
   int runNumber = 1;
   NexusPublisher streamer(publisher, broker, topic, runTopic, detSpecTopic,
-                          filename, detSpecFilename, quietMode);
+                          filename, detSpecFilename, quietMode, randomMode);
 
   // Publish the same data repeatedly, with incrementing run numbers
   while (true) {

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -38,7 +38,7 @@ TEST_F(NexusPublisherTest, test_create_message_data) {
   auto eventData = streamer.createMessageData(static_cast<hsize_t>(1), 1);
 
   std::string rawbuf;
-  eventData[0]->getBufferPointer(rawbuf);
+  eventData[0]->getBufferPointer(rawbuf, 0);
 
   auto receivedEventData = EventData();
   EXPECT_TRUE(receivedEventData.decodeMessage(
@@ -60,7 +60,7 @@ TEST_F(NexusPublisherTest, test_create_message_data_with_SE_events) {
       streamer.createMessageData(static_cast<hsize_t>(frameNumber), 1);
 
   std::string rawbuf;
-  eventData[0]->getBufferPointer(rawbuf);
+  eventData[0]->getBufferPointer(rawbuf, 0);
 
   auto receivedEventData = EventData();
   EXPECT_TRUE(receivedEventData.decodeMessage(
@@ -83,7 +83,7 @@ TEST_F(NexusPublisherTest, test_create_message_data_3_message_per_frame) {
       streamer.createMessageData(static_cast<hsize_t>(frameNumber), 3);
 
   std::string rawbuf;
-  eventData[0]->getBufferPointer(rawbuf);
+  eventData[0]->getBufferPointer(rawbuf, 0);
 
   auto receivedEventData = EventData();
   EXPECT_TRUE(receivedEventData.decodeMessage(
@@ -95,7 +95,7 @@ TEST_F(NexusPublisherTest, test_create_message_data_3_message_per_frame) {
   EXPECT_FALSE(receivedEventData.getEndOfFrame());
   EXPECT_FALSE(receivedEventData.getEndOfRun());
 
-  eventData[2]->getBufferPointer(rawbuf);
+  eventData[2]->getBufferPointer(rawbuf, 1);
   EXPECT_TRUE(receivedEventData.decodeMessage(
       reinterpret_cast<const uint8_t *>(rawbuf.c_str())));
   // Last message in frame should have remaining 256 events
@@ -113,7 +113,7 @@ TEST_F(NexusPublisherTest,
       streamer.createMessageData(static_cast<hsize_t>(frameNumber), 3);
 
   std::string rawbuf;
-  eventData[0]->getBufferPointer(rawbuf);
+  eventData[0]->getBufferPointer(rawbuf, 0);
 
   auto receivedData = RunData();
   // Should return false as this is not run data
@@ -129,7 +129,7 @@ TEST_F(NexusPublisherTest,
   EXPECT_FALSE(receivedEventData.getEndOfFrame());
   EXPECT_FALSE(receivedEventData.getEndOfRun());
 
-  eventData[2]->getBufferPointer(rawbuf);
+  eventData[2]->getBufferPointer(rawbuf, 0);
   EXPECT_TRUE(receivedEventData.decodeMessage(
       reinterpret_cast<const uint8_t *>(rawbuf.c_str())));
   // Last message should be the last message in the frame and in the run

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -24,7 +24,8 @@ public:
 
     NexusPublisher streamer(publisher, broker, topic, runTopic, detSpecTopic,
                             testDataPath + "SANS_test_reduced.hdf5",
-                            testDataPath + "spectrum_gastubes_01.dat", quiet);
+                            testDataPath + "spectrum_gastubes_01.dat", quiet,
+                            false);
     return streamer;
   }
 };
@@ -159,14 +160,12 @@ TEST_F(NexusPublisherTest, test_stream_data) {
 
   EXPECT_CALL(*publisher.get(), setUp(broker, topic, runTopic, detSpecTopic))
       .Times(AtLeast(1));
-  //EXPECT_CALL(*publisher.get(), sendEventMessage(_, _))
-  //    .Times(numberOfFrames + 1); // +1 for run data message
 
   // test that messages have sequential id numbers
   Sequence s1;
-  for (uint64_t messageID = 0; messageID <= numberOfFrames;
-       messageID++) {
-    EXPECT_CALL(*publisher.get(), sendEventMessage(CheckMessageID(messageID), _))
+  for (uint64_t messageID = 0; messageID <= numberOfFrames; messageID++) {
+    EXPECT_CALL(*publisher.get(),
+                sendEventMessage(CheckMessageID(messageID), _))
         .InSequence(s1);
   }
 
@@ -176,7 +175,8 @@ TEST_F(NexusPublisherTest, test_stream_data) {
 
   NexusPublisher streamer(publisher, broker, topic, runTopic, detSpecTopic,
                           testDataPath + "SANS_test_reduced.hdf5",
-                          testDataPath + "spectrum_gastubes_01.dat", true);
+                          testDataPath + "spectrum_gastubes_01.dat", true,
+                          false);
   EXPECT_NO_THROW(streamer.streamData(maxEventsPerFramePart, 1, false));
 }
 
@@ -202,7 +202,8 @@ TEST_F(NexusPublisherTest, test_stream_data_multiple_messages_per_frame) {
 
   NexusPublisher streamer(publisher, broker, topic, runTopic, detSpecTopic,
                           testDataPath + "SANS_test_reduced.hdf5",
-                          testDataPath + "spectrum_gastubes_01.dat", true);
+                          testDataPath + "spectrum_gastubes_01.dat", true,
+                          true);
   EXPECT_NO_THROW(streamer.streamData(maxEventsPerFramePart, 1, false));
 }
 


### PR DESCRIPTION
Closes #15 

Message id is included in messages published to the event data topic.
Launching the producer with the "-u" option publishes messages in a random order for testing purposes.
Unit tests and README are updated.
