### PR TITLE
Add number of spectra to detspec map messages

### DIFF
--- a/event_data/include/DetectorSpectrumMapData.h
+++ b/event_data/include/DetectorSpectrumMapData.h
@@ -11,18 +11,18 @@ public:
   flatbuffers::unique_ptr_t getBufferPointer(std::string &buffer);
   void decodeMessage(const uint8_t *buf);
 
-  size_t getNumberOfEntries() { return m_numberOfEntries; }
+  int32_t getNumberOfEntries() { return m_numberOfEntries; }
   std::vector<int32_t> getDetectors() { return m_detectors; }
   std::vector<int32_t> getSpectra() { return m_spectra; }
   size_t getBufferSize() { return m_bufferSize; }
 
-  void setNumberOfEntries(size_t numberOfEntries) {
+  void setNumberOfEntries(int32_t numberOfEntries) {
     m_numberOfEntries = numberOfEntries;
   }
 
 private:
   void readFile(const std::string &filename);
-  size_t m_numberOfEntries = 0;
+  int32_t m_numberOfEntries = 0;
   size_t m_bufferSize = 0;
   std::vector<int32_t> m_detectors;
   std::vector<int32_t> m_spectra;

--- a/event_data/include/det_spec_mapping_schema_generated.h
+++ b/event_data/include/det_spec_mapping_schema_generated.h
@@ -13,16 +13,19 @@ struct SpectraDetectorMapping;
 struct SpectraDetectorMapping FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum {
     VT_SPEC = 4,
-    VT_DET = 6
+    VT_DET = 6,
+    VT_N_SPECTRA = 8
   };
   const flatbuffers::Vector<int32_t> *spec() const { return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_SPEC); }
   const flatbuffers::Vector<int32_t> *det() const { return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_DET); }
+  int32_t n_spectra() const { return GetField<int32_t>(VT_N_SPECTRA, 0); }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<flatbuffers::uoffset_t>(verifier, VT_SPEC) &&
            verifier.Verify(spec()) &&
            VerifyField<flatbuffers::uoffset_t>(verifier, VT_DET) &&
            verifier.Verify(det()) &&
+           VerifyField<int32_t>(verifier, VT_N_SPECTRA) &&
            verifier.EndTable();
   }
 };
@@ -32,18 +35,21 @@ struct SpectraDetectorMappingBuilder {
   flatbuffers::uoffset_t start_;
   void add_spec(flatbuffers::Offset<flatbuffers::Vector<int32_t>> spec) { fbb_.AddOffset(SpectraDetectorMapping::VT_SPEC, spec); }
   void add_det(flatbuffers::Offset<flatbuffers::Vector<int32_t>> det) { fbb_.AddOffset(SpectraDetectorMapping::VT_DET, det); }
+  void add_n_spectra(int32_t n_spectra) { fbb_.AddElement<int32_t>(SpectraDetectorMapping::VT_N_SPECTRA, n_spectra, 0); }
   SpectraDetectorMappingBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb) { start_ = fbb_.StartTable(); }
   SpectraDetectorMappingBuilder &operator=(const SpectraDetectorMappingBuilder &);
   flatbuffers::Offset<SpectraDetectorMapping> Finish() {
-    auto o = flatbuffers::Offset<SpectraDetectorMapping>(fbb_.EndTable(start_, 2));
+    auto o = flatbuffers::Offset<SpectraDetectorMapping>(fbb_.EndTable(start_, 3));
     return o;
   }
 };
 
 inline flatbuffers::Offset<SpectraDetectorMapping> CreateSpectraDetectorMapping(flatbuffers::FlatBufferBuilder &_fbb,
    flatbuffers::Offset<flatbuffers::Vector<int32_t>> spec = 0,
-   flatbuffers::Offset<flatbuffers::Vector<int32_t>> det = 0) {
+   flatbuffers::Offset<flatbuffers::Vector<int32_t>> det = 0,
+   int32_t n_spectra = 0) {
   SpectraDetectorMappingBuilder builder_(_fbb);
+  builder_.add_n_spectra(n_spectra);
   builder_.add_det(det);
   builder_.add_spec(spec);
   return builder_.Finish();

--- a/event_data/src/DetectorSpectrumMapData.cpp
+++ b/event_data/src/DetectorSpectrumMapData.cpp
@@ -13,8 +13,8 @@ void DetectorSpectrumMapData::readFile(const std::string &filename) {
   std::getline(infile, line); // line with the number of entries
   std::istringstream iss(line);
   iss >> m_numberOfEntries;
-  m_detectors.resize(m_numberOfEntries);
-  m_spectra.resize(m_numberOfEntries);
+  m_detectors.resize(static_cast<size_t>(m_numberOfEntries));
+  m_spectra.resize(static_cast<size_t>(m_numberOfEntries));
   std::getline(infile, line); // discard third line
   size_t entryNumber = 0;
   while (std::getline(infile, line)) {
@@ -32,9 +32,9 @@ void DetectorSpectrumMapData::decodeMessage(const uint8_t *buf) {
 
   auto detFBVector = messageData->det();
   auto specFBVector = messageData->spec();
-  setNumberOfEntries(detFBVector->size());
-  m_detectors.resize(m_numberOfEntries);
-  m_spectra.resize(m_numberOfEntries);
+  setNumberOfEntries(messageData->n_spectra());
+  m_detectors.resize(static_cast<size_t>(m_numberOfEntries));
+  m_spectra.resize(static_cast<size_t>(m_numberOfEntries));
   std::copy(detFBVector->begin(), detFBVector->end(), m_detectors.begin());
   std::copy(specFBVector->begin(), specFBVector->end(), m_spectra.begin());
 }
@@ -45,7 +45,7 @@ DetectorSpectrumMapData::getBufferPointer(std::string &buffer) {
 
   auto messageFlatbuf = ISISStream::CreateSpectraDetectorMapping(
       builder, builder.CreateVector(m_spectra),
-      builder.CreateVector(m_detectors));
+      builder.CreateVector(m_detectors), m_numberOfEntries);
   builder.Finish(messageFlatbuf);
 
   auto bufferpointer =

--- a/event_data/src/det_spec_mapping_schema.fbs
+++ b/event_data/src/det_spec_mapping_schema.fbs
@@ -7,6 +7,7 @@ namespace ISISStream;
 table SpectraDetectorMapping {
     spec : [int];
     det : [int];
+    n_spectra : int;
 }
 
 root_type SpectraDetectorMapping;


### PR DESCRIPTION
Closes #20 

Added number of spectra to detector-spectra map messages. The field in the flatbuffer schema is `n_spectra : int`.
