### PR TITLE
Make period numbers start from 0, update unit tests

### DIFF
--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -156,7 +156,8 @@ int32_t NexusFileReader::getPeriodNumber() {
   int32_t periodNumber;
   dataset.read(&periodNumber, PredType::NATIVE_INT32);
 
-  return periodNumber;
+// -1 as period number starts at 1 in NeXus files but 0 everywhere else
+  return periodNumber - 1;
 }
 
 /**

--- a/nexus_file_reader/test/NexusFileReaderTest.cpp
+++ b/nexus_file_reader/test/NexusFileReaderTest.cpp
@@ -75,7 +75,7 @@ TEST(NexusFileReaderTest, get_event_tofs_too_high_frame_number) {
 TEST(NexusFileReaderTest, get_period_number) {
   extern std::string testDataPath;
   auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
-  EXPECT_EQ(1, fileReader.getPeriodNumber());
+  EXPECT_EQ(0, fileReader.getPeriodNumber());
 }
 
 TEST(NexusFileReaderTest, get_proton_charge) {

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -47,7 +47,7 @@ TEST_F(NexusPublisherTest, test_create_message_data) {
   EXPECT_EQ(770, receivedEventData.getNumberOfEvents());
   EXPECT_EQ(1, receivedEventData.getFrameNumber());
   EXPECT_FLOAT_EQ(0.001105368, receivedEventData.getProtonCharge());
-  EXPECT_EQ(1, receivedEventData.getPeriod());
+  EXPECT_EQ(0, receivedEventData.getPeriod());
   EXPECT_FLOAT_EQ(3.0399999618530273, receivedEventData.getFrameTime());
   auto sEEventsVector = receivedEventData.getSEEvents();
   // Expect no sample environment events in this message
@@ -69,7 +69,7 @@ TEST_F(NexusPublisherTest, test_create_message_data_with_SE_events) {
   EXPECT_EQ(794, receivedEventData.getNumberOfEvents());
   EXPECT_EQ(frameNumber, receivedEventData.getFrameNumber());
   EXPECT_FLOAT_EQ(0.001105368, receivedEventData.getProtonCharge());
-  EXPECT_EQ(1, receivedEventData.getPeriod());
+  EXPECT_EQ(0, receivedEventData.getPeriod());
   EXPECT_FLOAT_EQ(3.9389999, receivedEventData.getFrameTime());
   auto sEEventsVector = receivedEventData.getSEEvents();
   // Expect some sample environment events in this message


### PR DESCRIPTION
Closes #22 

Stream expects period numbers to start from 0, not from 1 as they do in NeXus files.
