### PR TITLE
Fix the value of the number of periods in run messages

### DIFF
--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -35,6 +35,7 @@ public:
   std::vector<valueType> get1DDataset(H5::DataType dataType,
                                       const std::string &datasetName);
   std::vector<std::string> get1DStringDataset(const std::string &datasetName);
+  int32_t getNumberOfPeriods();
 
 private:
   size_t findFrameNumberOfTime(float time);

--- a/nexus_file_reader/src/NexusFileReader.cpp
+++ b/nexus_file_reader/src/NexusFileReader.cpp
@@ -95,7 +95,7 @@ DataType NexusFileReader::getDatasetType(const std::string &datasetName) {
   return dataset.getDataType();
 }
 
-template <typename valueType>
+template<typename valueType>
 std::vector<valueType>
 NexusFileReader::get1DDataset(DataType dataType,
                               const std::string &datasetName) {
@@ -158,6 +158,16 @@ int32_t NexusFileReader::getPeriodNumber() {
 
 // -1 as period number starts at 1 in NeXus files but 0 everywhere else
   return periodNumber - 1;
+}
+
+/**
+ * Get the number of DAE periods
+ *
+ * @return - the number of periods
+ */
+int32_t NexusFileReader::getNumberOfPeriods() {
+  auto periodNumbers = get1DDataset<int32_t>(PredType::NATIVE_INT32, "/raw_data_1/periods/number");
+  return static_cast<int32_t>(periodNumbers.size());
 }
 
 /**
@@ -244,7 +254,7 @@ double NexusFileReader::getFrameTime(hsize_t frameNumber) {
   return frameTime;
 }
 
-template <typename T>
+template<typename T>
 T NexusFileReader::getSingleValueFromDataset(const std::string &datasetName,
                                              H5::PredType datatype,
                                              hsize_t offset) {

--- a/nexus_file_reader/test/NexusFileReaderTest.cpp
+++ b/nexus_file_reader/test/NexusFileReaderTest.cpp
@@ -153,3 +153,9 @@ TEST(NexusFileReaderTest, get_sEEvent_map) {
   EXPECT_EQ(4, eventVector.size());
   EXPECT_EQ("Guide_Pressure", eventVector[0]->getName());
 }
+
+TEST(NexusFileReaderTest, get_number_of_periods) {
+  extern std::string testDataPath;
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5");
+  EXPECT_EQ(1, fileReader.getNumberOfPeriods());
+}

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -119,7 +119,7 @@ void NexusPublisher::addSEEventsToMessage(
  */
 std::shared_ptr<RunData> NexusPublisher::createRunMessageData(int runNumber) {
   auto runData = std::make_shared<RunData>();
-  runData->setNumberOfPeriods(m_fileReader->getPeriodNumber());
+  runData->setNumberOfPeriods(m_fileReader->getNumberOfPeriods());
   runData->setInstrumentName(m_fileReader->getInstrumentName());
   runData->setRunNumber(runNumber);
   auto now = std::chrono::system_clock::now();


### PR DESCRIPTION
Fixes #24 
It was using the value of the first period number. Now using the size of the period number dataset.
New method in fileReader and covered with a test.
