### PR TITLE
Use Kafka timestamps

### DIFF
--- a/event_data/include/RunData.h
+++ b/event_data/include/RunData.h
@@ -9,15 +9,17 @@ public:
   bool decodeMessage(const uint8_t *buf);
   flatbuffers::unique_ptr_t getEventBufferPointer(std::string &buffer,
                                                   uint64_t messageID);
-  flatbuffers::unique_ptr_t getRunBufferPointer(std::string &buffer);
+  flatbuffers::unique_ptr_t getRunStartBufferPointer(std::string &buffer);
+  flatbuffers::unique_ptr_t getRunStopBufferPointer(std::string &buffer);
 
   void setRunNumber(int32_t runNumber) { m_runNumber = runNumber; }
   void setInstrumentName(const std::string &instrumentName) {
     m_instrumentName = instrumentName;
   }
   void setStartTime(const std::string &inputTime);
+  void setStopTime(const std::string &inputTime);
   void setStartTime(uint64_t inputTime) { m_startTime = inputTime; }
-  void setStreamOffset(int64_t streamOffset) { m_streamOffset = streamOffset; }
+  void setStopTime(uint64_t inputTime) { m_stopTime = inputTime; }
   void setNumberOfPeriods(int32_t numberOfPeriods) {
     m_numberOfPeriods = numberOfPeriods;
   }
@@ -25,18 +27,20 @@ public:
   int32_t getRunNumber() { return m_runNumber; }
   std::string getInstrumentName() { return m_instrumentName; }
   uint64_t getStartTime() { return m_startTime; }
+  uint64_t getStopTime() { return m_stopTime; }
   size_t getBufferSize() { return m_bufferSize; }
-  int64_t getStreamOffset() { return m_streamOffset; }
   int32_t getNumberOfPeriods() { return m_numberOfPeriods; }
 
   std::string runInfo();
 
 private:
+  uint64_t timeStringToUint64(const std::string &inputTime);
+
   uint64_t m_startTime = 0;
+  uint64_t m_stopTime = 0;
   int32_t m_runNumber = 0;
   std::string m_instrumentName = "";
   size_t m_bufferSize = 0;
-  int64_t m_streamOffset = 0;
   int32_t m_numberOfPeriods = 0;
 };
 

--- a/event_data/include/event_schema_generated.h
+++ b/event_data/include/event_schema_generated.h
@@ -8,6 +8,8 @@
 #include "run_info_schema_generated.h"
 
 namespace ISISStream {
+struct RunStart;
+struct RunStop;
 struct RunInfo;
 }  // namespace ISISStream
 

--- a/event_data/include/run_info_schema_generated.h
+++ b/event_data/include/run_info_schema_generated.h
@@ -8,20 +8,37 @@
 
 namespace ISISStream {
 
+struct RunStart;
+struct RunStop;
 struct RunInfo;
 
-struct RunInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+enum InfoTypes {
+  InfoTypes_NONE = 0,
+  InfoTypes_RunStart = 1,
+  InfoTypes_RunStop = 2,
+  InfoTypes_MIN = InfoTypes_NONE,
+  InfoTypes_MAX = InfoTypes_RunStop
+};
+
+inline const char **EnumNamesInfoTypes() {
+  static const char *names[] = { "NONE", "RunStart", "RunStop", nullptr };
+  return names;
+}
+
+inline const char *EnumNameInfoTypes(InfoTypes e) { return EnumNamesInfoTypes()[static_cast<int>(e)]; }
+
+inline bool VerifyInfoTypes(flatbuffers::Verifier &verifier, const void *union_obj, InfoTypes type);
+
+struct RunStart FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum {
     VT_START_TIME = 4,
     VT_RUN_NUMBER = 6,
     VT_INST_NAME = 8,
-    VT_STREAM_OFFSET = 10,
-    VT_N_PERIODS = 12
+    VT_N_PERIODS = 10
   };
   uint64_t start_time() const { return GetField<uint64_t>(VT_START_TIME, 0); }
   int32_t run_number() const { return GetField<int32_t>(VT_RUN_NUMBER, 0); }
   const flatbuffers::String *inst_name() const { return GetPointer<const flatbuffers::String *>(VT_INST_NAME); }
-  int64_t stream_offset() const { return GetField<int64_t>(VT_STREAM_OFFSET, 0); }
   int32_t n_periods() const { return GetField<int32_t>(VT_N_PERIODS, 0); }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -29,8 +46,82 @@ struct RunInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<int32_t>(verifier, VT_RUN_NUMBER) &&
            VerifyField<flatbuffers::uoffset_t>(verifier, VT_INST_NAME) &&
            verifier.Verify(inst_name()) &&
-           VerifyField<int64_t>(verifier, VT_STREAM_OFFSET) &&
            VerifyField<int32_t>(verifier, VT_N_PERIODS) &&
+           verifier.EndTable();
+  }
+};
+
+struct RunStartBuilder {
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  void add_start_time(uint64_t start_time) { fbb_.AddElement<uint64_t>(RunStart::VT_START_TIME, start_time, 0); }
+  void add_run_number(int32_t run_number) { fbb_.AddElement<int32_t>(RunStart::VT_RUN_NUMBER, run_number, 0); }
+  void add_inst_name(flatbuffers::Offset<flatbuffers::String> inst_name) { fbb_.AddOffset(RunStart::VT_INST_NAME, inst_name); }
+  void add_n_periods(int32_t n_periods) { fbb_.AddElement<int32_t>(RunStart::VT_N_PERIODS, n_periods, 0); }
+  RunStartBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb) { start_ = fbb_.StartTable(); }
+  RunStartBuilder &operator=(const RunStartBuilder &);
+  flatbuffers::Offset<RunStart> Finish() {
+    auto o = flatbuffers::Offset<RunStart>(fbb_.EndTable(start_, 4));
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<RunStart> CreateRunStart(flatbuffers::FlatBufferBuilder &_fbb,
+   uint64_t start_time = 0,
+   int32_t run_number = 0,
+   flatbuffers::Offset<flatbuffers::String> inst_name = 0,
+   int32_t n_periods = 0) {
+  RunStartBuilder builder_(_fbb);
+  builder_.add_start_time(start_time);
+  builder_.add_n_periods(n_periods);
+  builder_.add_inst_name(inst_name);
+  builder_.add_run_number(run_number);
+  return builder_.Finish();
+}
+
+struct RunStop FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  enum {
+    VT_STOP_TIME = 4
+  };
+  uint64_t stop_time() const { return GetField<uint64_t>(VT_STOP_TIME, 0); }
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<uint64_t>(verifier, VT_STOP_TIME) &&
+           verifier.EndTable();
+  }
+};
+
+struct RunStopBuilder {
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  void add_stop_time(uint64_t stop_time) { fbb_.AddElement<uint64_t>(RunStop::VT_STOP_TIME, stop_time, 0); }
+  RunStopBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb) { start_ = fbb_.StartTable(); }
+  RunStopBuilder &operator=(const RunStopBuilder &);
+  flatbuffers::Offset<RunStop> Finish() {
+    auto o = flatbuffers::Offset<RunStop>(fbb_.EndTable(start_, 1));
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<RunStop> CreateRunStop(flatbuffers::FlatBufferBuilder &_fbb,
+   uint64_t stop_time = 0) {
+  RunStopBuilder builder_(_fbb);
+  builder_.add_stop_time(stop_time);
+  return builder_.Finish();
+}
+
+struct RunInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  enum {
+    VT_INFO_TYPE_TYPE = 4,
+    VT_INFO_TYPE = 6
+  };
+  InfoTypes info_type_type() const { return static_cast<InfoTypes>(GetField<uint8_t>(VT_INFO_TYPE_TYPE, 0)); }
+  const void *info_type() const { return GetPointer<const void *>(VT_INFO_TYPE); }
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<uint8_t>(verifier, VT_INFO_TYPE_TYPE) &&
+           VerifyField<flatbuffers::uoffset_t>(verifier, VT_INFO_TYPE) &&
+           VerifyInfoTypes(verifier, info_type(), info_type_type()) &&
            verifier.EndTable();
   }
 };
@@ -38,32 +129,32 @@ struct RunInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct RunInfoBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_start_time(uint64_t start_time) { fbb_.AddElement<uint64_t>(RunInfo::VT_START_TIME, start_time, 0); }
-  void add_run_number(int32_t run_number) { fbb_.AddElement<int32_t>(RunInfo::VT_RUN_NUMBER, run_number, 0); }
-  void add_inst_name(flatbuffers::Offset<flatbuffers::String> inst_name) { fbb_.AddOffset(RunInfo::VT_INST_NAME, inst_name); }
-  void add_stream_offset(int64_t stream_offset) { fbb_.AddElement<int64_t>(RunInfo::VT_STREAM_OFFSET, stream_offset, 0); }
-  void add_n_periods(int32_t n_periods) { fbb_.AddElement<int32_t>(RunInfo::VT_N_PERIODS, n_periods, 0); }
+  void add_info_type_type(InfoTypes info_type_type) { fbb_.AddElement<uint8_t>(RunInfo::VT_INFO_TYPE_TYPE, static_cast<uint8_t>(info_type_type), 0); }
+  void add_info_type(flatbuffers::Offset<void> info_type) { fbb_.AddOffset(RunInfo::VT_INFO_TYPE, info_type); }
   RunInfoBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb) { start_ = fbb_.StartTable(); }
   RunInfoBuilder &operator=(const RunInfoBuilder &);
   flatbuffers::Offset<RunInfo> Finish() {
-    auto o = flatbuffers::Offset<RunInfo>(fbb_.EndTable(start_, 5));
+    auto o = flatbuffers::Offset<RunInfo>(fbb_.EndTable(start_, 2));
     return o;
   }
 };
 
 inline flatbuffers::Offset<RunInfo> CreateRunInfo(flatbuffers::FlatBufferBuilder &_fbb,
-   uint64_t start_time = 0,
-   int32_t run_number = 0,
-   flatbuffers::Offset<flatbuffers::String> inst_name = 0,
-   int64_t stream_offset = 0,
-   int32_t n_periods = 0) {
+   InfoTypes info_type_type = InfoTypes_NONE,
+   flatbuffers::Offset<void> info_type = 0) {
   RunInfoBuilder builder_(_fbb);
-  builder_.add_stream_offset(stream_offset);
-  builder_.add_start_time(start_time);
-  builder_.add_n_periods(n_periods);
-  builder_.add_inst_name(inst_name);
-  builder_.add_run_number(run_number);
+  builder_.add_info_type(info_type);
+  builder_.add_info_type_type(info_type_type);
   return builder_.Finish();
+}
+
+inline bool VerifyInfoTypes(flatbuffers::Verifier &verifier, const void *union_obj, InfoTypes type) {
+  switch (type) {
+    case InfoTypes_NONE: return true;
+    case InfoTypes_RunStart: return verifier.VerifyTable(reinterpret_cast<const RunStart *>(union_obj));
+    case InfoTypes_RunStop: return verifier.VerifyTable(reinterpret_cast<const RunStop *>(union_obj));
+    default: return false;
+  }
 }
 
 inline const ISISStream::RunInfo *GetRunInfo(const void *buf) { return flatbuffers::GetRoot<ISISStream::RunInfo>(buf); }

--- a/event_data/src/run_info_schema.fbs
+++ b/event_data/src/run_info_schema.fbs
@@ -3,13 +3,22 @@
 namespace ISISStream;
 
 // this will be used in a separate kafka topic, used to pick up where current run starts
-// if you join late 
-table RunInfo {
+// if you join late
+table RunStart {
     start_time : ulong;
-	run_number : int;
-	inst_name : string;
-	stream_offset : long;   // offset into kafka topic for start of current data collection run
-	n_periods : int;
+    run_number : int;
+    inst_name : string;
+    n_periods : int;
+}
+
+table RunStop {
+    stop_time : ulong;
+}
+
+union InfoTypes { RunStart, RunStop }
+
+table RunInfo {
+    info_type : InfoTypes;
 }
 
 root_type RunInfo;

--- a/event_data/test/RunDataTest.cpp
+++ b/event_data/test/RunDataTest.cpp
@@ -12,16 +12,19 @@ TEST(RunDataTest, set_and_get_start_time) {
   EXPECT_EQ(1470905418, rundata.getStartTime());
 }
 
+TEST(RunDataTest, set_and_get_stop_time) {
+  auto rundata = RunData();
+  EXPECT_NO_THROW(rundata.setStopTime("2016-08-13T13:32:09"));
+  EXPECT_EQ(1471095129, rundata.getStopTime());
+
+  EXPECT_NO_THROW(rundata.setStopTime(1471095129));
+  EXPECT_EQ(1471095129, rundata.getStopTime());
+}
+
 TEST(RunDataTest, set_and_get_run_number) {
   auto rundata = RunData();
   EXPECT_NO_THROW(rundata.setRunNumber(42));
   EXPECT_EQ(42, rundata.getRunNumber());
-}
-
-TEST(RunDataTest, set_and_get_stream_offset) {
-  auto rundata = RunData();
-  EXPECT_NO_THROW(rundata.setStreamOffset(42));
-  EXPECT_EQ(42, rundata.getStreamOffset());
 }
 
 TEST(RunDataTest, set_and_get_instrument_name) {
@@ -37,7 +40,7 @@ TEST(RunDataTest, get_RunInfo) {
   EXPECT_NO_THROW(rundata.setStartTime("2016-08-11T08:50:18"));
 
   EXPECT_EQ("Run number: 42, Instrument name: SANS2D, Start time: "
-            "2016-08-11T08:50:18, Run offset: 0",
+            "2016-08-11T08:50:18",
             rundata.runInfo());
 }
 

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -29,6 +29,7 @@ private:
   int64_t createAndSendMessage(std::string &rawbuf, size_t frameNumber,
                                const int messagesPerFrame);
   void createAndSendSampleEnvMessages(std::string &sampleEnvBuf, size_t frameNumber);
+  int64_t createAndSendRunStopMessage(std::string &rawbuf);
   void reportProgress(const float progress);
 
   std::shared_ptr<EventPublisher> m_publisher;

--- a/nexus_producer/src/KafkaEventPublisher.cpp
+++ b/nexus_producer/src/KafkaEventPublisher.cpp
@@ -25,6 +25,7 @@ void KafkaEventPublisher::setUp(const std::string &broker,
   conf->set("message.max.bytes", "10000000", error_str);
   conf->set("fetch.message.max.bytes", "10000000", error_str);
   conf->set("replica.fetch.max.bytes", "10000000", error_str);
+  conf->set("api.version.request", "true", error_str);
 
   if (!m_compression.empty()) {
     if (conf->set("compression.codec", m_compression, error_str) !=

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -217,13 +217,12 @@ void NexusPublisher::createAndSendSampleEnvMessages(std::string &sampleEnvBuf,
 int64_t NexusPublisher::createAndSendRunMessage(std::string &rawbuf,
                                                 int runNumber) {
   auto messageData = createRunMessageData(runNumber);
-  messageData->setStreamOffset(m_publisher->getCurrentOffset());
   auto buffer_uptr = messageData->getEventBufferPointer(rawbuf, m_messageID);
   m_messageID++;
   // publish to both topics
   m_publisher->sendEventMessage(reinterpret_cast<char *>(buffer_uptr.get()),
                                 messageData->getBufferSize());
-  buffer_uptr = messageData->getRunBufferPointer(rawbuf);
+  buffer_uptr = messageData->getRunStartBufferPointer(rawbuf);
   m_publisher->sendRunMessage(reinterpret_cast<char *>(buffer_uptr.get()),
                               messageData->getBufferSize());
   std::cout << std::endl << "Publishing new run:" << std::endl;

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -142,7 +142,6 @@ TEST_F(NexusPublisherTest, test_stream_data) {
   EXPECT_CALL(*publisher.get(), sendSampleEnvMessage(_, _)).Times(16);
   EXPECT_CALL(*publisher.get(), sendRunMessage(_, _)).Times(1);
   EXPECT_CALL(*publisher.get(), sendDetSpecMessage(_, _)).Times(1);
-  EXPECT_CALL(*publisher.get(), getCurrentOffset()).Times(1);
 
   NexusPublisher streamer(publisher, broker, instrumentName,
                           testDataPath + "SANS_test_reduced.hdf5",
@@ -168,7 +167,6 @@ TEST_F(NexusPublisherTest, test_stream_data_multiple_messages_per_frame) {
   EXPECT_CALL(*publisher.get(), sendSampleEnvMessage(_, _)).Times(16);
   EXPECT_CALL(*publisher.get(), sendRunMessage(_, _)).Times(1);
   EXPECT_CALL(*publisher.get(), sendDetSpecMessage(_, _)).Times(1);
-  EXPECT_CALL(*publisher.get(), getCurrentOffset()).Times(1);
 
   NexusPublisher streamer(publisher, broker, instrumentName,
                           testDataPath + "SANS_test_reduced.hdf5",

--- a/nexus_producer/test/NexusPublisherTest.cpp
+++ b/nexus_producer/test/NexusPublisherTest.cpp
@@ -140,7 +140,8 @@ TEST_F(NexusPublisherTest, test_stream_data) {
   }
 
   EXPECT_CALL(*publisher.get(), sendSampleEnvMessage(_, _)).Times(16);
-  EXPECT_CALL(*publisher.get(), sendRunMessage(_, _)).Times(1);
+  EXPECT_CALL(*publisher.get(), sendRunMessage(_, _))
+      .Times(2); // Start and stop messages
   EXPECT_CALL(*publisher.get(), sendDetSpecMessage(_, _)).Times(1);
 
   NexusPublisher streamer(publisher, broker, instrumentName,
@@ -165,7 +166,8 @@ TEST_F(NexusPublisherTest, test_stream_data_multiple_messages_per_frame) {
       .Times(AtLeast(1));
   EXPECT_CALL(*publisher.get(), sendEventMessage(_, _)).Times(1292);
   EXPECT_CALL(*publisher.get(), sendSampleEnvMessage(_, _)).Times(16);
-  EXPECT_CALL(*publisher.get(), sendRunMessage(_, _)).Times(1);
+  EXPECT_CALL(*publisher.get(), sendRunMessage(_, _))
+      .Times(2); // Start and stop messages
   EXPECT_CALL(*publisher.get(), sendDetSpecMessage(_, _)).Times(1);
 
   NexusPublisher streamer(publisher, broker, instrumentName,


### PR DESCRIPTION
Fixes #35 

Enabled using Kafka header timestamps so that offsets can be looked up by timestamp.
`RunStart` and `RunStop` messages are now sent in the `runInfo` topic, which will unblock #33.