### PR TITLE
Add file indentifiers by calling generated finish method

### DIFF
--- a/event_data/src/EventData.cpp
+++ b/event_data/src/EventData.cpp
@@ -42,7 +42,7 @@ flatbuffers::unique_ptr_t EventData::getBufferPointer(std::string &buffer,
       builder.CreateVector(m_detId), FacilityData_ISISData,
       isisDataMessage.Union());
 
-  builder.Finish(eventMessage);
+  FinishEventMessageBuffer(builder, eventMessage);
 
   auto bufferpointer =
       reinterpret_cast<const char *>(builder.GetBufferPointer());

--- a/event_data/src/RunData.cpp
+++ b/event_data/src/RunData.cpp
@@ -58,7 +58,7 @@ RunData::getRunStartBufferPointer(std::string &buffer) {
   auto messageRunInfo =
       CreateRunInfo(builder, InfoTypes_RunStart, messageRunStart.Union());
 
-  builder.Finish(messageRunInfo);
+  FinishRunInfoBuffer(builder, messageRunInfo);
 
   auto bufferpointer =
       reinterpret_cast<const char *>(builder.GetBufferPointer());
@@ -77,7 +77,7 @@ RunData::getRunStopBufferPointer(std::string &buffer) {
   auto messageRunInfo =
       CreateRunInfo(builder, InfoTypes_RunStop, messageRunStop.Union());
 
-  builder.Finish(messageRunInfo);
+  FinishRunInfoBuffer(builder, messageRunInfo);
 
   auto bufferpointer =
       reinterpret_cast<const char *>(builder.GetBufferPointer());

--- a/event_data/test/EventDataTest.cpp
+++ b/event_data/test/EventDataTest.cpp
@@ -51,9 +51,21 @@ TEST(EventDataTest, get_buffer_size) {
   std::string rawbuf;
   EXPECT_NO_THROW(events.getBufferPointer(rawbuf, 0));
   EXPECT_TRUE(events.getBufferSize() > 0);
-  std::string eventIdentifier = "ev42";
+}
+
+TEST(EventDataTest, check_buffer_includes_file_identifier) {
+  auto events = EventData();
+
+  std::vector<uint32_t> detIds = {1, 2, 3, 4};
+  std::vector<uint32_t> tofs = {4, 3, 2, 1};
+
+  events.setDetId(detIds);
+  events.setTof(tofs);
+
+  std::string rawbuf;
+  EXPECT_NO_THROW(events.getBufferPointer(rawbuf, 0));
+
+  auto eventIdentifier = EventMessageIdentifier();
   EXPECT_TRUE(flatbuffers::BufferHasIdentifier(
-      reinterpret_cast<const uint8_t *>(rawbuf.c_str()),
-      eventIdentifier.c_str()));
-  EXPECT_EQ(rawbuf.at(5), eventIdentifier.at(1));
+      reinterpret_cast<const uint8_t *>(rawbuf.c_str()), eventIdentifier));
 }

--- a/event_data/test/EventDataTest.cpp
+++ b/event_data/test/EventDataTest.cpp
@@ -51,4 +51,9 @@ TEST(EventDataTest, get_buffer_size) {
   std::string rawbuf;
   EXPECT_NO_THROW(events.getBufferPointer(rawbuf, 0));
   EXPECT_TRUE(events.getBufferSize() > 0);
+  std::string eventIdentifier = "ev42";
+  EXPECT_TRUE(flatbuffers::BufferHasIdentifier(
+      reinterpret_cast<const uint8_t *>(rawbuf.c_str()),
+      eventIdentifier.c_str()));
+  EXPECT_EQ(rawbuf.at(5), eventIdentifier.at(1));
 }

--- a/event_data/test/RunDataTest.cpp
+++ b/event_data/test/RunDataTest.cpp
@@ -75,3 +75,15 @@ TEST(RunDataTest, encode_and_decode_RunStop) {
       reinterpret_cast<const uint8_t *>(rawbuf.c_str())));
   EXPECT_EQ(1470905418, receivedRunData.getStopTime());
 }
+
+TEST(RunDataTest, check_buffer_includes_file_identifier) {
+  auto rundata = RunData();
+  EXPECT_NO_THROW(rundata.setStopTime("2016-08-11T08:50:18"));
+
+  std::string rawbuf;
+  EXPECT_NO_THROW(rundata.getRunStopBufferPointer(rawbuf));
+
+  auto runIdentifier = RunInfoIdentifier();
+  EXPECT_TRUE(flatbuffers::BufferHasIdentifier(
+      reinterpret_cast<const uint8_t *>(rawbuf.c_str()), runIdentifier));
+}


### PR DESCRIPTION
File identifiers were not being added to flatbuffers due to using builder.finish() instead of the flatc generated `finishX` method.