### PR TITLE
Make sample env times relative to start of the simulated run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:17.04
 
-ARG LIBRDKAFKA_VER="0.11.0"
+ARG LIBRDKAFKA_VER="0.11.1"
 
 RUN apt-get -y update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES
 # dependencies - libhdf5, build-essential, git
 ENV BUILD_PACKAGES "build-essential git libhdf5-dev cmake"
 RUN apt-get install $BUILD_PACKAGES -y
-RUN git clone https://github.com/ScreamingUdder/isis_nexus_streamer_for_mantid.git
+RUN mkdir isis_nexus_streamer_for_mantid
+ADD . isis_nexus_streamer_for_mantid/
 RUN mkdir nexus_publisher && \
     cd nexus_publisher && \
     cmake ../isis_nexus_streamer_for_mantid && \

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ message.max.bytes=10000000
 We use this Ansible playbook to deploy Kafka: https://github.com/ScreamingUdder/ansible-kafka-centos
 
 ## Containers
-The docker-compose script can be used to launch a single-broker Kafka cluster and the NeXus streamer. The broker is available on port 9092 of the host machine.
+The docker-compose script can be used to launch a single-broker Kafka cluster and the NeXus streamer.
 Run the following in the root directory of the repository to launch the containers.
+
 ```
 docker-compose up
 ```
+The streamer publishes some test data using the instrument name TEST. The Kafka broker is accessible at `localhost:9092`.
 
 ## Dependencies
 Currently requires having `librdkafka` and the HDF5 C++ library installed. If `tcmalloc` is available then it will be used, but it is not a requirement.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '2'
 
 services:
   producer:
+    network_mode: host
     build: .
     depends_on:
       - kafka
@@ -10,6 +11,7 @@ services:
     image: wurstmeister/kafka
     depends_on:
       - zookeeper
+    hostname: kafka
     ports:
       - "9092:9092"
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - kafka
 
   kafka:
-    image: wurstmeister/kafka
+    image: wurstmeister/kafka:0.11.0.1
     depends_on:
       - zookeeper
     hostname: kafka

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,24 +7,22 @@ services:
       - kafka
 
   kafka:
-    image: ches/kafka:0.10.2.0
+    image: wurstmeister/kafka
     depends_on:
       - zookeeper
-    environment:
-      ZOOKEEPER_IP: zookeeper
     ports:
-      - '9092:9092'  # Kafka broker
-      - '7203:7203'  # JMX
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: localhost
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_MESSAGE_MAX_BYTES: 10000000
+      KAFKA_BROKER_ID: 0
     volumes:
-      - kafka-data:/data
-      - kafka-logs:/logs
+      - /var/run/docker.sock:/var/run/docker.sock
 
   zookeeper:
     image: zookeeper:3.4
     restart: unless-stopped
     ports:
       - '2181:2181'
-
-volumes:
-  kafka-data:
-  kafka-logs:

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -11,4 +11,4 @@ while [ $OUT -ne 0 -a  $i -ne 10  ]; do
    i=$[$i+1]
 done
 
-nexus_producer/main_nexusPublisher -f SANS_test.nxs -b kafka -i SANS2D -d spectrum_gastubes_01.dat
+nexus_producer/main_nexusPublisher -f SANS_test.nxs -b kafka -i INSTR -d spectrum_gastubes_01.dat -z

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,14 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 
 # Wait for Kafka to be ready before starting the publisher
 kafkacat -b kafka -L
 OUT=$?
 i="0"
-while [ $OUT -ne 0 -a  $i -ne 10  ]; do
+while [ $OUT -ne 0 -a  $i -ne 5  ]; do
    echo "Waiting for Kafka to be ready"
-   kafkacat -b kafka -L
+   kafkacat -b localhost -L
    OUT=$?
-   i=$[$i+1]
+   let i=$i+1
+   echo $i
 done
+if [ $i -eq 5 ]
+then
+   echo "Kafka broker not accessible at producer launch"
+   exit 1
+fi
 
-nexus_producer/main_nexusPublisher -f SANS_test.nxs -b kafka -i INSTR -d spectrum_gastubes_01.dat -z
+nexus_producer/main_nexusPublisher -f SANS_test.nxs -b localhost -i TEST -d spectrum_gastubes_01.dat -z

--- a/event_data/include/RunData.h
+++ b/event_data/include/RunData.h
@@ -35,6 +35,7 @@ public:
 
 private:
   uint64_t timeStringToUint64(const std::string &inputTime);
+  uint64_t secondsToNanoseconds(time_t timeInSeconds);
 
   uint64_t m_startTime = 0;
   uint64_t m_stopTime = 0;

--- a/event_data/include/RunData.h
+++ b/event_data/include/RunData.h
@@ -18,7 +18,10 @@ public:
   }
   void setStartTime(const std::string &inputTime);
   void setStopTime(const std::string &inputTime);
-  void setStartTime(uint64_t inputTime) { m_startTime = inputTime; }
+  void setStartTimeInSeconds(time_t inputTime);
+  void setStartTimeInNanoseconds(uint64_t inputTime) {
+    m_startTime = inputTime;
+  };
   void setStopTime(uint64_t inputTime) { m_stopTime = inputTime; }
   void setNumberOfPeriods(int32_t numberOfPeriods) {
     m_numberOfPeriods = numberOfPeriods;

--- a/event_data/include/SampleEnvironmentEvent.h
+++ b/event_data/include/SampleEnvironmentEvent.h
@@ -11,9 +11,9 @@
 
 class SampleEnvironmentEvent {
 public:
-  SampleEnvironmentEvent(int64_t runStart, float eventTime,
+  SampleEnvironmentEvent(uint64_t runStart, float eventTime,
                          const std::string &name)
-      : m_runStartSecondsPastUnixEpoch(runStart), m_time(eventTime),
+      : m_runStartNanosecondsPastUnixEpoch(runStart), m_time(eventTime),
         m_name(name) {}
   virtual ~SampleEnvironmentEvent() {}
 
@@ -28,7 +28,7 @@ public:
 protected:
   size_t m_bufferSize;
   std::string m_name;
-  int64_t m_runStartSecondsPastUnixEpoch;
+  uint64_t m_runStartNanosecondsPastUnixEpoch;
   float m_time;
 };
 

--- a/event_data/include/SampleEnvironmentEventDouble.h
+++ b/event_data/include/SampleEnvironmentEventDouble.h
@@ -6,7 +6,7 @@
 class SampleEnvironmentEventDouble : public SampleEnvironmentEvent {
 public:
   SampleEnvironmentEventDouble(const std::string &name, float time,
-                               double value, int64_t runStart)
+                               double value, uint64_t runStart)
       : m_value(value), SampleEnvironmentEvent(runStart, time, name) {}
 
   flatbuffers::Offset<LogData>

--- a/event_data/include/SampleEnvironmentEventInt.h
+++ b/event_data/include/SampleEnvironmentEventInt.h
@@ -6,7 +6,7 @@
 class SampleEnvironmentEventInt : public SampleEnvironmentEvent {
 public:
   SampleEnvironmentEventInt(const std::string &name, float time, int32_t value,
-                            int64_t runStart)
+                            uint64_t runStart)
       : m_value(value), SampleEnvironmentEvent(runStart, time, name) {}
 
   flatbuffers::Offset<LogData>

--- a/event_data/include/SampleEnvironmentEventLong.h
+++ b/event_data/include/SampleEnvironmentEventLong.h
@@ -6,7 +6,7 @@
 class SampleEnvironmentEventLong : public SampleEnvironmentEvent {
 public:
   SampleEnvironmentEventLong(const std::string &name, float time, int64_t value,
-                             int64_t runStart)
+                             uint64_t runStart)
       : m_value(value), SampleEnvironmentEvent(runStart, time, name) {}
 
   flatbuffers::Offset<LogData>

--- a/event_data/src/RunData.cpp
+++ b/event_data/src/RunData.cpp
@@ -14,6 +14,11 @@ void RunData::setStopTime(const std::string &inputTime) {
   m_stopTime = timeStringToUint64(inputTime);
 }
 
+uint64_t RunData::secondsToNanoseconds(time_t timeInSeconds) {
+  uint64_t timeInNanoseconds = static_cast<uint64_t>(timeInSeconds) * 1000000000L;
+  return timeInNanoseconds;
+}
+
 uint64_t RunData::timeStringToUint64(const std::string &inputTime) {
   std::tm tmb = {};
 #if (defined(__GNUC__) && __GNUC__ >= 5) || defined(_MSC_VER)
@@ -24,8 +29,7 @@ uint64_t RunData::timeStringToUint64(const std::string &inputTime) {
   // gcc < 5 does not have std::get_time implemented
   strptime(inputTime.c_str(), "%Y-%m-%dT%H:%M:%S", &tmb);
 #endif
-  // convert seconds to nanoseconds
-  uint64_t nsSinceEpoch = static_cast<uint64_t>(std::mktime(&tmb)) * 1000000000;
+  auto nsSinceEpoch = secondsToNanoseconds(std::mktime(&tmb));
   return nsSinceEpoch;
 }
 

--- a/event_data/src/RunData.cpp
+++ b/event_data/src/RunData.cpp
@@ -1,6 +1,5 @@
 #include "RunData.h"
 
-#include <array>
 #include <ctime>
 #include <iomanip>
 #include <iostream>
@@ -24,7 +23,9 @@ uint64_t RunData::timeStringToUint64(const std::string &inputTime) {
   // gcc < 5 does not have std::get_time implemented
   strptime(inputTime.c_str(), "%Y-%m-%dT%H:%M:%S", &tmb);
 #endif
-  return static_cast<uint64_t>(std::mktime(&tmb));
+  // convert seconds to nanoseconds
+  uint64_t nsSinceEpoch = static_cast<uint64_t>(std::mktime(&tmb)) * 1000000000;
+  return nsSinceEpoch;
 }
 
 bool RunData::decodeMessage(const uint8_t *buf) {
@@ -95,7 +96,8 @@ std::string RunData::runInfo() {
   ssRunInfo << "Run number: " << m_runNumber << ", "
             << "Instrument name: " << m_instrumentName << ", "
             << "Start time: ";
-  const auto sTime = static_cast<time_t>(m_startTime);
+  // convert nanoseconds to seconds
+  const auto sTime = static_cast<time_t>(m_startTime / 1000000000);
 #if defined(__GNUC__) && __GNUC__ >= 5
   ssRunInfo << std::put_time(std::gmtime(&sTime), "%Y-%m-%dT%H:%M:%S");
 #else

--- a/event_data/src/RunData.cpp
+++ b/event_data/src/RunData.cpp
@@ -10,12 +10,17 @@ void RunData::setStartTime(const std::string &inputTime) {
   m_startTime = timeStringToUint64(inputTime);
 }
 
+void RunData::setStartTimeInSeconds(time_t inputTime) {
+  m_startTime = secondsToNanoseconds(inputTime);
+}
+
 void RunData::setStopTime(const std::string &inputTime) {
   m_stopTime = timeStringToUint64(inputTime);
 }
 
 uint64_t RunData::secondsToNanoseconds(time_t timeInSeconds) {
-  uint64_t timeInNanoseconds = static_cast<uint64_t>(timeInSeconds) * 1000000000L;
+  uint64_t timeInNanoseconds =
+      static_cast<uint64_t>(timeInSeconds) * 1000000000L;
   return timeInNanoseconds;
 }
 
@@ -38,7 +43,7 @@ bool RunData::decodeMessage(const uint8_t *buf) {
 
   if (runData->info_type_type() == InfoTypes_RunStart) {
     auto runStartData = static_cast<const RunStart *>(runData->info_type());
-    setStartTime(runStartData->start_time());
+    setStartTimeInNanoseconds(runStartData->start_time());
     setInstrumentName(runStartData->instrument_name()->str());
     setRunNumber(runStartData->run_number());
     setNumberOfPeriods(runStartData->n_periods());

--- a/event_data/src/RunData.cpp
+++ b/event_data/src/RunData.cpp
@@ -1,5 +1,6 @@
 #include "RunData.h"
 
+#include <array>
 #include <ctime>
 #include <iomanip>
 #include <iostream>

--- a/event_data/src/SampleEnvironmentEvent.cpp
+++ b/event_data/src/SampleEnvironmentEvent.cpp
@@ -2,8 +2,8 @@
 #include <cmath>
 
 uint64_t SampleEnvironmentEvent::getTimestamp() {
-  double secondsPastUnixEpoch = m_runStartSecondsPastUnixEpoch + m_time;
-  return static_cast<uint64_t>(secondsPastUnixEpoch * 1e9);
+  auto nanosecondsPastRunStart = static_cast<uint64_t>(m_time * 1e9);
+  return nanosecondsPastRunStart + m_runStartNanosecondsPastUnixEpoch;
 }
 
 flatbuffers::unique_ptr_t

--- a/event_data/test/RunDataTest.cpp
+++ b/event_data/test/RunDataTest.cpp
@@ -6,19 +6,19 @@ class RunDataTest : public ::testing::Test {};
 TEST(RunDataTest, set_and_get_start_time) {
   auto rundata = RunData();
   EXPECT_NO_THROW(rundata.setStartTime("2016-08-11T08:50:18"));
-  EXPECT_EQ(1470905418, rundata.getStartTime());
+  EXPECT_EQ(1470905418000000000, rundata.getStartTime());
 
-  EXPECT_NO_THROW(rundata.setStartTime(1470905418));
-  EXPECT_EQ(1470905418, rundata.getStartTime());
+  EXPECT_NO_THROW(rundata.setStartTime(1470905418000000000));
+  EXPECT_EQ(1470905418000000000, rundata.getStartTime());
 }
 
 TEST(RunDataTest, set_and_get_stop_time) {
   auto rundata = RunData();
   EXPECT_NO_THROW(rundata.setStopTime("2016-08-13T13:32:09"));
-  EXPECT_EQ(1471095129, rundata.getStopTime());
+  EXPECT_EQ(1471095129000000000, rundata.getStopTime());
 
-  EXPECT_NO_THROW(rundata.setStopTime(1471095129));
-  EXPECT_EQ(1471095129, rundata.getStopTime());
+  EXPECT_NO_THROW(rundata.setStopTime(1471095129000000000));
+  EXPECT_EQ(1471095129000000000, rundata.getStopTime());
 }
 
 TEST(RunDataTest, set_and_get_run_number) {
@@ -59,7 +59,7 @@ TEST(RunDataTest, encode_and_decode_RunData) {
       reinterpret_cast<const uint8_t *>(rawbuf.c_str())));
   EXPECT_EQ(42, receivedRunData.getRunNumber());
   EXPECT_EQ("SANS2D", receivedRunData.getInstrumentName());
-  EXPECT_EQ(1470905418, receivedRunData.getStartTime());
+  EXPECT_EQ(1470905418000000000, receivedRunData.getStartTime());
   EXPECT_EQ(1, receivedRunData.getNumberOfPeriods());
 }
 
@@ -73,7 +73,7 @@ TEST(RunDataTest, encode_and_decode_RunStop) {
   auto receivedRunData = RunData();
   EXPECT_TRUE(receivedRunData.decodeMessage(
       reinterpret_cast<const uint8_t *>(rawbuf.c_str())));
-  EXPECT_EQ(1470905418, receivedRunData.getStopTime());
+  EXPECT_EQ(1470905418000000000, receivedRunData.getStopTime());
 }
 
 TEST(RunDataTest, check_buffer_includes_file_identifier) {

--- a/event_data/test/RunDataTest.cpp
+++ b/event_data/test/RunDataTest.cpp
@@ -8,7 +8,7 @@ TEST(RunDataTest, set_and_get_start_time) {
   EXPECT_NO_THROW(rundata.setStartTime("2016-08-11T08:50:18"));
   EXPECT_EQ(1470905418000000000, rundata.getStartTime());
 
-  EXPECT_NO_THROW(rundata.setStartTime(1470905418000000000));
+  EXPECT_NO_THROW(rundata.setStartTimeInSeconds(1470905418));
   EXPECT_EQ(1470905418000000000, rundata.getStartTime());
 }
 

--- a/nexus_file_reader/include/NexusFileReader.h
+++ b/nexus_file_reader/include/NexusFileReader.h
@@ -14,7 +14,7 @@ typedef std::vector<std::shared_ptr<SampleEnvironmentEvent>> sEEventVector;
 
 class NexusFileReader {
 public:
-  NexusFileReader(const std::string &filename);
+  NexusFileReader(const std::string &filename, uint64_t runStartTime);
 
   hsize_t getFileSize();
   uint64_t getTotalEventCount();
@@ -38,7 +38,7 @@ public:
   uint64_t getFrameStartOffset();
 
 private:
-  int64_t m_runStart;
+  uint64_t m_runStart;
   size_t findFrameNumberOfTime(float time);
   template <typename T>
   T getSingleValueFromDataset(const std::string &dataset, H5::PredType datatype,
@@ -46,7 +46,7 @@ private:
   hsize_t getFrameStart(hsize_t frameNumber);
   H5FilePtr m_file = nullptr;
   size_t m_numberOfFrames;
-  int64_t convertStringToUnixTime(const std::string &timeString);
+  uint64_t convertStringToUnixTime(const std::string &timeString);
   uint64_t m_frameStartOffset;
 };
 

--- a/nexus_file_reader/test/NexusFileReaderTest.cpp
+++ b/nexus_file_reader/test/NexusFileReaderTest.cpp
@@ -8,35 +8,35 @@ extern std::string testDataPath;
 
 TEST(NexusFileReaderTest, nexus_file_open_not_exist) {
   H5::Exception::dontPrint();
-  EXPECT_THROW(NexusFileReader(testDataPath + "not_exist_file.nxs"),
+  EXPECT_THROW(NexusFileReader(testDataPath + "not_exist_file.nxs", 0),
                H5::FileIException);
 }
 
 TEST(NexusFileReaderTest, nexus_file_open_exists) {
-  EXPECT_NO_THROW(NexusFileReader(testDataPath + "SANS_test.nxs"));
+  EXPECT_NO_THROW(NexusFileReader(testDataPath + "SANS_test.nxs", 0));
 }
 
 TEST(NexusFileReaderTest, nexus_uncompressed_file_open_exists) {
-  EXPECT_NO_THROW(NexusFileReader(testDataPath + "SANS_test_reduced.hdf5"));
+  EXPECT_NO_THROW(NexusFileReader(testDataPath + "SANS_test_reduced.hdf5", 0));
 }
 
 TEST(NexusFileReaderTest, nexus_read_file_size) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs", 0);
   EXPECT_EQ(104602171, fileReader.getFileSize());
 }
 
 TEST(NexusFileReaderTest, nexus_read_number_events) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs", 0);
   EXPECT_EQ(14258850, fileReader.getTotalEventCount());
 }
 
 TEST(NexusFileReaderTest, nexus_read_number_frames) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs", 0);
   EXPECT_EQ(18131, fileReader.getNumberOfFrames());
 }
 
 TEST(NexusFileReaderTest, get_detIds_first_frame) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs", 0);
   std::vector<uint32_t> detIds;
   EXPECT_TRUE(fileReader.getEventDetIds(detIds, 0));
   EXPECT_EQ(99406, detIds[0]);
@@ -44,8 +44,7 @@ TEST(NexusFileReaderTest, get_detIds_first_frame) {
 }
 
 TEST(NexusFileReaderTest, get_event_tofs) {
-  extern std::string testDataPath;
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs", 0);
   std::vector<uint32_t> eventTofs;
   EXPECT_TRUE(fileReader.getEventTofs(eventTofs, 0));
   EXPECT_EQ(11660506, eventTofs[0]);
@@ -53,52 +52,47 @@ TEST(NexusFileReaderTest, get_event_tofs) {
 }
 
 TEST(NexusFileReaderTest, get_detIds_too_high_frame_number) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs", 0);
   std::vector<uint32_t> detIds;
   EXPECT_FALSE(fileReader.getEventDetIds(detIds, 3000000));
 }
 
 TEST(NexusFileReaderTest, get_event_tofs_too_high_frame_number) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs", 0);
   std::vector<uint32_t> eventTofs;
   EXPECT_FALSE(fileReader.getEventTofs(eventTofs, 3000000));
 }
 
 TEST(NexusFileReaderTest, get_period_number) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs", 0);
   EXPECT_EQ(0, fileReader.getPeriodNumber());
 }
 
 TEST(NexusFileReaderTest, get_proton_charge) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs", 0);
   EXPECT_FLOAT_EQ(0.001105368, fileReader.getProtonCharge(0));
   EXPECT_FLOAT_EQ(0.001105368, fileReader.getProtonCharge(7));
 }
 
 TEST(NexusFileReaderTest, get_number_of_events_in_frame) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs", 0);
   EXPECT_EQ(794, fileReader.getNumberOfEventsInFrame(0));
   EXPECT_EQ(781, fileReader.getNumberOfEventsInFrame(7));
 }
 
 TEST(NexusFileReaderTest, get_frame_time) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs", 0);
   EXPECT_EQ(1460429934940000057, fileReader.getFrameTime(0));
   EXPECT_EQ(1460429935638999939, fileReader.getFrameTime(7));
 }
 
-TEST(NexusFileReaderTest, get_run_start_time) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
-  EXPECT_EQ(1460429932, fileReader.getRunStartTime());
-}
-
 TEST(NexusFileReaderTest, get_instrument_name) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test.nxs", 0);
   EXPECT_EQ("SANS2D", fileReader.getInstrumentName());
 }
 
 TEST(NexusFileReaderTest, get_se_names) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5", 0);
   auto seNamesFromFile = fileReader.getNamesInGroup("/raw_data_1/selog");
   EXPECT_THAT(seNamesFromFile,
               ::testing::ElementsAre("Guide_Pressure", "Rear_Det_X",
@@ -107,7 +101,7 @@ TEST(NexusFileReaderTest, get_se_names) {
 }
 
 TEST(NexusFileReaderTest, get_1D_dataset_float) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5", 0);
   auto valueVector = fileReader.get1DDataset<float>(
       H5::PredType::NATIVE_FLOAT,
       "/raw_data_1/selog/Guide_Pressure/value_log/value");
@@ -115,23 +109,23 @@ TEST(NexusFileReaderTest, get_1D_dataset_float) {
 }
 
 TEST(NexusFileReaderTest, get_1D_dataset_string) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5", 0);
   auto eventVector = fileReader.get1DStringDataset(
       "/raw_data_1/selog/SECI_OUT_OF_RANGE_BLOCK/value_log/value");
   EXPECT_EQ("Fast_Shutter", eventVector[0].substr(0, 12));
 }
 
 TEST(NexusFileReaderTest, get_sEEvent_map) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5", 0);
   auto eventMap = fileReader.getSEEventMap();
   auto eventVector = eventMap[10];
   EXPECT_EQ(4, eventVector.size());
   EXPECT_EQ("Guide_Pressure", eventVector[0]->getName());
   EXPECT_EQ("TEMP1", eventVector[3]->getName());
-  EXPECT_EQ(1460429952000000000, eventVector[3]->getTimestamp());
+  EXPECT_EQ(1000000000, eventVector[3]->getTimestamp());
 }
 
 TEST(NexusFileReaderTest, get_number_of_periods) {
-  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5");
+  auto fileReader = NexusFileReader(testDataPath + "SANS_test_reduced.hdf5", 0);
   EXPECT_EQ(1, fileReader.getNumberOfPeriods());
 }

--- a/nexus_producer/include/EventPublisher.h
+++ b/nexus_producer/include/EventPublisher.h
@@ -12,6 +12,7 @@ public:
   virtual void sendRunMessage(char *buf, size_t messageSize) = 0;
   virtual void sendDetSpecMessage(char *buf, size_t messageSize) = 0;
   virtual void sendSampleEnvMessage(char *buf, size_t messageSize) = 0;
+  virtual void flushSendQueue() = 0;
   virtual int64_t getCurrentOffset() = 0;
 };
 

--- a/nexus_producer/include/KafkaEventPublisher.h
+++ b/nexus_producer/include/KafkaEventPublisher.h
@@ -11,7 +11,7 @@ public:
   KafkaEventPublisher(){};
   KafkaEventPublisher(const std::string &compression)
       : m_compression(compression){};
-  ~KafkaEventPublisher() { RdKafka::wait_destroyed(5000); };
+  ~KafkaEventPublisher();
 
   std::shared_ptr<RdKafka::Topic>
   createTopicHandle(const std::string &topicPrefix,

--- a/nexus_producer/include/KafkaEventPublisher.h
+++ b/nexus_producer/include/KafkaEventPublisher.h
@@ -24,6 +24,7 @@ public:
   void sendDetSpecMessage(char *buf, size_t messageSize) override;
   void sendSampleEnvMessage(char *buf, size_t messageSize) override;
   int64_t getCurrentOffset() override;
+  void flushSendQueue() override;
 
 private:
   void sendMessage(char *buf, size_t messageSize,

--- a/nexus_producer/include/MockEventPublisher.h
+++ b/nexus_producer/include/MockEventPublisher.h
@@ -13,6 +13,7 @@ public:
   MOCK_METHOD2(sendEventMessage, void(char *buf, size_t messageSize));
   MOCK_METHOD2(sendSampleEnvMessage, void(char *buf, size_t messageSize));
   MOCK_METHOD0(getCurrentOffset, int64_t());
+  MOCK_METHOD0(flushSendQueue, void());
 };
 
 #endif // ISIS_NEXUS_STREAMER_MOCKEVENTPUBLISHER_H

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -13,8 +13,7 @@ class NexusPublisher {
 public:
   NexusPublisher(std::shared_ptr<EventPublisher> publisher,
                  const std::string &brokerAddress,
-                 const std::string &instrumentName,
-                 const std::string &filename,
+                 const std::string &instrumentName, const std::string &filename,
                  const std::string &detSpecMapFilename, const bool quietMode);
   std::vector<std::shared_ptr<EventData>>
   createMessageData(hsize_t frameNumber);
@@ -26,7 +25,8 @@ public:
 
 private:
   size_t createAndSendMessage(std::string &rawbuf, size_t frameNumber);
-  void createAndSendSampleEnvMessages(std::string &sampleEnvBuf, size_t frameNumber);
+  void createAndSendSampleEnvMessages(std::string &sampleEnvBuf,
+                                      size_t frameNumber);
   size_t createAndSendRunStopMessage(std::string &rawbuf);
   void reportProgress(const float progress);
 
@@ -36,6 +36,7 @@ private:
   std::string m_detSpecMapFilename;
   std::unordered_map<hsize_t, sEEventVector> m_sEEventMap;
   uint64_t m_messageID = 0;
+  uint64_t m_runStartTime;
 };
 
 #endif // ISIS_NEXUS_STREAMER_NEXUSPUBLISHER_H

--- a/nexus_producer/src/KafkaEventPublisher.cpp
+++ b/nexus_producer/src/KafkaEventPublisher.cpp
@@ -65,6 +65,16 @@ void KafkaEventPublisher::setUp(const std::string &broker,
 }
 
 /**
+ * Wait for all messages in the current producer queue to be published
+ */
+void KafkaEventPublisher::flushSendQueue() {
+  auto error = m_producer_ptr->flush(2000);
+  if (error != RdKafka::ERR_NO_ERROR) {
+    std::cerr << "Producer queue flush failed." << std::endl;
+  }
+}
+
+/**
  * Create a topic handle
  *
  * @param topic_str : name of the topic

--- a/nexus_producer/src/KafkaEventPublisher.cpp
+++ b/nexus_producer/src/KafkaEventPublisher.cpp
@@ -2,6 +2,15 @@
 
 #include "KafkaEventPublisher.h"
 
+KafkaEventPublisher::~KafkaEventPublisher() {
+  auto error = m_producer_ptr->flush(2000);
+  if (error != RdKafka::ERR_NO_ERROR) {
+    std::cerr << "% Producer flush failed: " << RdKafka::err2str(error)
+              << std::endl;
+  }
+  RdKafka::wait_destroyed(5000);
+}
+
 /**
  * Set up the configuration for the publisher and initialise it
  *

--- a/nexus_producer/src/KafkaEventPublisher.cpp
+++ b/nexus_producer/src/KafkaEventPublisher.cpp
@@ -3,11 +3,7 @@
 #include "KafkaEventPublisher.h"
 
 KafkaEventPublisher::~KafkaEventPublisher() {
-  auto error = m_producer_ptr->flush(2000);
-  if (error != RdKafka::ERR_NO_ERROR) {
-    std::cerr << "% Producer flush failed: " << RdKafka::err2str(error)
-              << std::endl;
-  }
+  flushSendQueue();
   RdKafka::wait_destroyed(5000);
 }
 

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<RunData> NexusPublisher::createRunMessageData(int runNumber) {
   runData->setRunNumber(runNumber);
   auto now = std::chrono::system_clock::now();
   auto now_c = std::chrono::system_clock::to_time_t(now);
-  runData->setStartTime(static_cast<uint64_t>(now_c) * 1000000000);
+  runData->setStartTimeInSeconds(static_cast<uint64_t>(now_c) * 1000000000);
   return runData;
 }
 

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -79,8 +79,7 @@ std::shared_ptr<RunData> NexusPublisher::createRunMessageData(int runNumber) {
   runData->setInstrumentName(m_fileReader->getInstrumentName());
   runData->setRunNumber(runNumber);
   auto now = std::chrono::system_clock::now();
-  auto now_c = std::chrono::system_clock::to_time_t(now);
-  runData->setStartTimeInSeconds(static_cast<uint64_t>(now_c) * 1000000000);
+  runData->setStartTimeInSeconds(std::chrono::system_clock::to_time_t(now));
   return runData;
 }
 

--- a/nexus_producer/src/NexusPublisher.cpp
+++ b/nexus_producer/src/NexusPublisher.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<RunData> NexusPublisher::createRunMessageData(int runNumber) {
   runData->setRunNumber(runNumber);
   auto now = std::chrono::system_clock::now();
   auto now_c = std::chrono::system_clock::to_time_t(now);
-  runData->setStartTime(static_cast<uint64_t>(now_c));
+  runData->setStartTime(static_cast<uint64_t>(now_c) * 1000000000);
   return runData;
 }
 
@@ -197,7 +197,7 @@ size_t NexusPublisher::createAndSendRunStopMessage(std::string &rawbuf) {
   auto runData = std::make_shared<RunData>();
   auto now = std::chrono::system_clock::now();
   auto now_c = std::chrono::system_clock::to_time_t(now);
-  runData->setStopTime(static_cast<uint64_t>(now_c));
+  runData->setStopTime(static_cast<uint64_t>(now_c) * 1000000000);
 
   auto buffer_uptr = runData->getRunStopBufferPointer(rawbuf);
   m_publisher->sendRunMessage(reinterpret_cast<char *>(buffer_uptr.get()),

--- a/travis.sh
+++ b/travis.sh
@@ -3,8 +3,8 @@
 echo "....fetching librdkafka dependency...."
 mkdir tmp_build
 cd tmp_build
-wget https://github.com/edenhill/librdkafka/archive/0.11.1.tar.gz
-tar -zxf 0.11.1.tar.gz
+wget https://github.com/edenhill/librdkafka/archive/v0.11.1.tar.gz
+tar -zxf v0.11.1.tar.gz
 echo ".....done....."
 cd librdkafka-0.11.1
 echo "....compiling librdkafka...."

--- a/travis.sh
+++ b/travis.sh
@@ -3,10 +3,10 @@
 echo "....fetching librdkafka dependency...."
 mkdir tmp_build
 cd tmp_build
-wget https://github.com/edenhill/librdkafka/archive/0.9.1.tar.gz
-tar -zxf 0.9.1.tar.gz
+wget https://github.com/edenhill/librdkafka/archive/0.11.1.tar.gz
+tar -zxf 0.11.1.tar.gz
 echo ".....done....."
-cd librdkafka-0.9.1
+cd librdkafka-0.11.1
 echo "....compiling librdkafka...."
 ./configure && make
 sudo make install


### PR DESCRIPTION
Closes #50 

**Please review and merge #49 first**

Timestamps for sample logs in the file are relative to the start of the run, to get absolute timestamps to send through Kafka they are now added to a run start time corresponding to when the file starts to stream rather than the run start timestamp recorded in the file.