### PR TITLE
Improve docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,47 @@
 FROM ubuntu:17.04
 
 ARG LIBRDKAFKA_VER="0.11.1"
+ARG KAFKACAT_VER="1.3.1"
 
-RUN apt-get -y update
+# Install dependencies
+ENV BUILD_PACKAGES "build-essential git curl zlib1g-dev python libhdf5-dev cmake"
+RUN apt-get -y update && apt-get install $BUILD_PACKAGES -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
 
 # Build librdkafka
-ENV BUILD_PACKAGES "build-essential zlib1g-dev unzip python"
-RUN apt-get install $BUILD_PACKAGES -y
-ADD https://github.com/edenhill/librdkafka/archive/v$LIBRDKAFKA_VER.zip /tmp/source.zip
+ADD https://github.com/edenhill/librdkafka/archive/v$LIBRDKAFKA_VER.tar.gz /tmp/source.tar.gz
 RUN cd /tmp && \
-    unzip source.zip && mv librdkafka-* librdkafka && \
+    tar -xzf source.tar.gz && mv librdkafka-* librdkafka && \
     cd /tmp/librdkafka && \
     ./configure && \
     make all && make install && \
-    make clean && ./configure --clean
-RUN AUTO_ADDED_PACKAGES=`apt-mark showauto`
-RUN apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES
-
-WORKDIR /build
+    make clean && ./configure --clean && \
+    ldconfig
 
 # Build kafkacat (to be used to check Kafka broker is running before launching clients)
-ENV BUILD_PACKAGES "build-essential git curl zlib1g-dev python"
-RUN apt-get install $BUILD_PACKAGES -y
-RUN git clone https://github.com/edenhill/kafkacat.git
-RUN cd kafkacat && \
-    ./bootstrap.sh && \
+ADD https://github.com/edenhill/kafkacat/archive/$KAFKACAT_VER.tar.gz /tmp/kafkacat_source.tar.gz
+RUN cd /tmp && \
+    tar -xzf kafkacat_source.tar.gz && \
+    mv kafkacat-* kafkacat && \
+    cd /tmp/kafkacat && sync && \
+    ./configure && make && \
     make install && \
     cd .. && rm -rf kafkacat
-RUN AUTO_ADDED_PACKAGES=`apt-mark showauto`
-RUN apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES
 
 # Build NeXus file streamer
-# dependencies - libhdf5, build-essential, git
-ENV BUILD_PACKAGES "build-essential git libhdf5-dev cmake"
-RUN apt-get install $BUILD_PACKAGES -y
+# dependencies - libhdf5, build-essential
 RUN mkdir isis_nexus_streamer_for_mantid
 ADD . isis_nexus_streamer_for_mantid/
 RUN mkdir nexus_publisher && \
     cd nexus_publisher && \
+    git config --global http.sslVerify false && \
     cmake ../isis_nexus_streamer_for_mantid && \
     make
-RUN AUTO_ADDED_PACKAGES=`apt-mark showauto`
-RUN apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES
 
 # Clean up
-RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN AUTO_ADDED_PACKAGES=`apt-mark showauto`
+RUN apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES
+RUN rm -rf /tmp/* /var/tmp/*
 
 ADD docker-start.sh nexus_publisher/docker-start.sh
 ADD data/SANS_test.nxs nexus_publisher/SANS_test.nxs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,3 +28,12 @@ services:
     restart: unless-stopped
     ports:
       - '2181:2181'
+
+  manager:
+    image: sheepkiller/kafka-manager:alpine
+    depends_on:
+      - producer
+    ports:
+      - "9000:9000"
+    environment:
+      ZK_HOSTS: zookeeper:2181


### PR DESCRIPTION
Changes to docker image:
- Reduce image size by using `--no-install-recommends` with `apt`.
- Use specific release version of kafkacat.
- Manually manage dependencies for kafkacat instead of using its bootstrap script.