### PR TITLE
Expose all config options for container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,9 @@ services:
     build: .
     depends_on:
       - kafka
+    environment:
+      SINGLE_RUN: "true"
+      SLOW_MODE: "false"
 
   kafka:
     image: wurstmeister/kafka:0.11.0.1

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -32,4 +32,12 @@ fi
 : ${KAFKA_BROKER_NAME:=localhost}
 : ${INSTRUMENT_NAME:=TEST}
 
-nexus_producer/main_nexusPublisher -f ${NEXUS_FILE_NAME} -b ${KAFKA_BROKER_NAME} -i ${INSTRUMENT_NAME} -d ${DETSPECMAP_FILE_NAME} -z
+ADDITIONAL_FLAGS=""
+if [ ${SINGLE_RUN:="true"} == "true" ]; then
+    ADDITIONAL_FLAGS="$ADDITIONAL_FLAGS -z"
+fi
+if [ ${SLOW_MODE:="false"} == "true" ]; then
+    ADDITIONAL_FLAGS="$ADDITIONAL_FLAGS -s"
+fi
+
+nexus_producer/main_nexusPublisher -f ${NEXUS_FILE_NAME} -b ${KAFKA_BROKER_NAME} -i ${INSTRUMENT_NAME} -d ${DETSPECMAP_FILE_NAME} ${ADDITIONAL_FLAGS}


### PR DESCRIPTION
Expose "slow mode" (roughly 10 frames of data per second) and "single run" as options for container.
Image and documentation are updated at https://hub.docker.com/r/screamingudder/nexusproducer/

Defaults are the same as the container behaved previously (publish a single run as fast as possible).