### PR TITLE
Use millisecond precision start time

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,9 @@ services:
     build: .
     depends_on:
       - kafka
+    environment:
+      SINGLE_RUN: "true"
+      SLOW_MODE: "false"
 
   kafka:
     image: wurstmeister/kafka:0.11.0.1

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -32,4 +32,12 @@ fi
 : ${KAFKA_BROKER_NAME:=localhost}
 : ${INSTRUMENT_NAME:=TEST}
 
-nexus_producer/main_nexusPublisher -f ${NEXUS_FILE_NAME} -b ${KAFKA_BROKER_NAME} -i ${INSTRUMENT_NAME} -d ${DETSPECMAP_FILE_NAME} -z
+ADDITIONAL_FLAGS=""
+if [ ${SINGLE_RUN:="true"} == "true" ]; then
+    ADDITIONAL_FLAGS="$ADDITIONAL_FLAGS -z"
+fi
+if [ ${SLOW_MODE:="false"} == "true" ]; then
+    ADDITIONAL_FLAGS="$ADDITIONAL_FLAGS -s"
+fi
+
+nexus_producer/main_nexusPublisher -f ${NEXUS_FILE_NAME} -b ${KAFKA_BROKER_NAME} -i ${INSTRUMENT_NAME} -d ${DETSPECMAP_FILE_NAME} ${ADDITIONAL_FLAGS}

--- a/event_data/include/RunData.h
+++ b/event_data/include/RunData.h
@@ -23,6 +23,7 @@ public:
     m_startTime = inputTime;
   };
   void setStopTime(uint64_t inputTime) { m_stopTime = inputTime; }
+  void setStartTime(uint64_t inputTime) { m_startTime = inputTime; }
   void setNumberOfPeriods(int32_t numberOfPeriods) {
     m_numberOfPeriods = numberOfPeriods;
   }

--- a/nexus_producer/include/NexusPublisher.h
+++ b/nexus_producer/include/NexusPublisher.h
@@ -24,6 +24,7 @@ public:
   void streamData(int runNumber, bool slow);
 
 private:
+  int64_t getTimeNowInNanoseconds();
   size_t createAndSendMessage(std::string &rawbuf, size_t frameNumber);
   void createAndSendSampleEnvMessages(std::string &sampleEnvBuf,
                                       size_t frameNumber);

--- a/nexus_producer/src/main.cpp
+++ b/nexus_producer/src/main.cpp
@@ -6,6 +6,8 @@
 #include <getopt.h>
 #endif
 #include <iostream>
+#include <chrono>
+#include <thread>
 
 #include "KafkaEventPublisher.h"
 #include "NexusPublisher.h"
@@ -91,6 +93,7 @@ int main(int argc, char **argv) {
   } else {
     while (true) {
       streamer.streamData(runNumber, slow);
+      std::this_thread::sleep_for(std::chrono::seconds(2));
       runNumber++;
     }
   }


### PR DESCRIPTION
**Merge #58 first!**

The run start time should have millisecond precision this is the precision of the timestamp used to look up start offsets in Kafka topics (using `rdkafka::offsetsForTimes()`).